### PR TITLE
feat(project): Implement CRUD for Project Address and refactor entity…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
 			<artifactId>h2</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/management/address/controller/ProjectAddressController.java
+++ b/src/main/java/com/management/address/controller/ProjectAddressController.java
@@ -3,6 +3,8 @@ package com.management.address.controller;
 import com.management.address.dto.ProjectAddressRequestDTO;
 import com.management.address.dto.ProjectAddressResponseDTO;
 import com.management.address.service.ProjectAddressService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -10,31 +12,36 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/projects/{projectId}/address")
+@RequestMapping("/api/projects/{projectId}/addresses")
+@Tag(name = "Projects")
 public class ProjectAddressController {
 
     @Autowired
     private ProjectAddressService projectAddressService;
 
     @PostMapping
+    @Operation(summary = "Creates a new address for a project")
     public ResponseEntity<ProjectAddressResponseDTO> createProjectAddress(@PathVariable Long projectId, @Valid @RequestBody ProjectAddressRequestDTO requestDTO) {
         ProjectAddressResponseDTO responseDTO = projectAddressService.createProjectAddress(projectId, requestDTO);
         return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);
     }
 
     @GetMapping
+    @Operation(summary = "Finds the address for a project")
     public ResponseEntity<ProjectAddressResponseDTO> getProjectAddress(@PathVariable Long projectId) {
         ProjectAddressResponseDTO responseDTO = projectAddressService.getProjectAddress(projectId);
         return ResponseEntity.ok(responseDTO);
     }
 
     @PutMapping
+    @Operation(summary = "Updates the address for a project")
     public ResponseEntity<ProjectAddressResponseDTO> updateProjectAddress(@PathVariable Long projectId, @Valid @RequestBody ProjectAddressRequestDTO requestDTO) {
         ProjectAddressResponseDTO responseDTO = projectAddressService.updateProjectAddress(projectId, requestDTO);
         return ResponseEntity.ok(responseDTO);
     }
 
     @DeleteMapping
+    @Operation(summary = "Deletes the address for a project")
     public ResponseEntity<Void> deleteProjectAddress(@PathVariable Long projectId) {
         projectAddressService.deleteProjectAddress(projectId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/management/address/controller/ProjectAddressController.java
+++ b/src/main/java/com/management/address/controller/ProjectAddressController.java
@@ -1,0 +1,42 @@
+package com.management.address.controller;
+
+import com.management.address.dto.ProjectAddressRequestDTO;
+import com.management.address.dto.ProjectAddressResponseDTO;
+import com.management.address.service.ProjectAddressService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/projects/{projectId}/address")
+public class ProjectAddressController {
+
+    @Autowired
+    private ProjectAddressService projectAddressService;
+
+    @PostMapping
+    public ResponseEntity<ProjectAddressResponseDTO> createProjectAddress(@PathVariable Long projectId, @Valid @RequestBody ProjectAddressRequestDTO requestDTO) {
+        ProjectAddressResponseDTO responseDTO = projectAddressService.createProjectAddress(projectId, requestDTO);
+        return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<ProjectAddressResponseDTO> getProjectAddress(@PathVariable Long projectId) {
+        ProjectAddressResponseDTO responseDTO = projectAddressService.getProjectAddress(projectId);
+        return ResponseEntity.ok(responseDTO);
+    }
+
+    @PutMapping
+    public ResponseEntity<ProjectAddressResponseDTO> updateProjectAddress(@PathVariable Long projectId, @Valid @RequestBody ProjectAddressRequestDTO requestDTO) {
+        ProjectAddressResponseDTO responseDTO = projectAddressService.updateProjectAddress(projectId, requestDTO);
+        return ResponseEntity.ok(responseDTO);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteProjectAddress(@PathVariable Long projectId) {
+        projectAddressService.deleteProjectAddress(projectId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/management/address/dto/ProjectAddressRequestDTO.java
+++ b/src/main/java/com/management/address/dto/ProjectAddressRequestDTO.java
@@ -1,0 +1,26 @@
+package com.management.address.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class ProjectAddressRequestDTO {
+
+    @NotBlank(message = "Street is mandatory")
+    private String street;
+
+    @NotBlank(message = "Number is mandatory")
+    private String number;
+
+    @NotBlank(message = "Neighborhood is mandatory")
+    private String neighborhood;
+
+    @NotBlank(message = "Zip code is mandatory")
+    private String zipCode;
+
+    private String complement;
+
+    @NotNull(message = "City ID is mandatory")
+    private Long cityId;
+}

--- a/src/main/java/com/management/address/dto/ProjectAddressResponseDTO.java
+++ b/src/main/java/com/management/address/dto/ProjectAddressResponseDTO.java
@@ -1,0 +1,15 @@
+package com.management.address.dto;
+
+import com.management.city.dto.CityResponseDTO;
+import lombok.Data;
+
+@Data
+public class ProjectAddressResponseDTO {
+    private Long id;
+    private String street;
+    private String number;
+    private String neighborhood;
+    private String zipCode;
+    private String complement;
+    private CityResponseDTO city;
+}

--- a/src/main/java/com/management/address/model/Address.java
+++ b/src/main/java/com/management/address/model/Address.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public class Address {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     private String street;
     private String number;
@@ -30,11 +30,11 @@ public class Address {
     }
 
     // Getters and Setters
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/address/repository/AddressRepository.java
+++ b/src/main/java/com/management/address/repository/AddressRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AddressRepository extends JpaRepository<Address, Integer> {
+public interface AddressRepository extends JpaRepository<Address, Long> {
 }

--- a/src/main/java/com/management/address/service/ProjectAddressService.java
+++ b/src/main/java/com/management/address/service/ProjectAddressService.java
@@ -78,7 +78,9 @@ public class ProjectAddressService {
             throw new ResourceNotFoundException("Address not found for project with id: " + projectId);
         }
 
+        Address address = project.getAddress();
         project.setAddress(null);
         projectRepository.save(project);
+        addressRepository.delete(address);
     }
 }

--- a/src/main/java/com/management/address/service/ProjectAddressService.java
+++ b/src/main/java/com/management/address/service/ProjectAddressService.java
@@ -1,0 +1,84 @@
+package com.management.address.service;
+
+import com.management.address.dto.ProjectAddressRequestDTO;
+import com.management.address.dto.ProjectAddressResponseDTO;
+import com.management.address.model.Address;
+import com.management.address.repository.AddressRepository;
+import com.management.city.repository.CityRepository;
+import com.management.exception.ResourceNotFoundException;
+import com.management.project.model.Project;
+import com.management.project.repository.ProjectRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProjectAddressService {
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private AddressRepository addressRepository;
+
+    @Autowired
+    private CityRepository cityRepository;
+
+    @Autowired
+    private ModelMapper modelMapper;
+
+    public ProjectAddressResponseDTO createProjectAddress(Long projectId, ProjectAddressRequestDTO requestDTO) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + projectId));
+
+        Address address = modelMapper.map(requestDTO, Address.class);
+        address.setCity(cityRepository.findById(requestDTO.getCityId())
+                .orElseThrow(() -> new ResourceNotFoundException("City not found with id: " + requestDTO.getCityId())));
+
+        project.setAddress(address);
+        projectRepository.save(project);
+
+        return modelMapper.map(address, ProjectAddressResponseDTO.class);
+    }
+
+    public ProjectAddressResponseDTO getProjectAddress(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + projectId));
+
+        if (project.getAddress() == null) {
+            throw new ResourceNotFoundException("Address not found for project with id: " + projectId);
+        }
+
+        return modelMapper.map(project.getAddress(), ProjectAddressResponseDTO.class);
+    }
+
+    public ProjectAddressResponseDTO updateProjectAddress(Long projectId, ProjectAddressRequestDTO requestDTO) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + projectId));
+
+        if (project.getAddress() == null) {
+            throw new ResourceNotFoundException("Address not found for project with id: " + projectId);
+        }
+
+        Address address = project.getAddress();
+        modelMapper.map(requestDTO, address);
+        address.setCity(cityRepository.findById(requestDTO.getCityId())
+                .orElseThrow(() -> new ResourceNotFoundException("City not found with id: " + requestDTO.getCityId())));
+
+        addressRepository.save(address);
+
+        return modelMapper.map(address, ProjectAddressResponseDTO.class);
+    }
+
+    public void deleteProjectAddress(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + projectId));
+
+        if (project.getAddress() == null) {
+            throw new ResourceNotFoundException("Address not found for project with id: " + projectId);
+        }
+
+        project.setAddress(null);
+        projectRepository.save(project);
+    }
+}

--- a/src/main/java/com/management/city/dto/CityResponseDTO.java
+++ b/src/main/java/com/management/city/dto/CityResponseDTO.java
@@ -1,0 +1,11 @@
+package com.management.city.dto;
+
+import com.management.state.dto.StateResponseDTO;
+import lombok.Data;
+
+@Data
+public class CityResponseDTO {
+    private Long id;
+    private String name;
+    private StateResponseDTO state;
+}

--- a/src/main/java/com/management/city/model/City.java
+++ b/src/main/java/com/management/city/model/City.java
@@ -8,7 +8,7 @@ import jakarta.persistence.*;
 public class City {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @Column(nullable = false)
     private String name;
@@ -18,11 +18,11 @@ public class City {
     private State state;
 
     // Getters and Setters
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/city/model/State.java
+++ b/src/main/java/com/management/city/model/State.java
@@ -7,17 +7,17 @@ import jakarta.persistence.*;
 public class State {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @Column(unique = true, nullable = false)
     private String uf;
 
     // Getters and Setters
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/city/repository/CityRepository.java
+++ b/src/main/java/com/management/city/repository/CityRepository.java
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface CityRepository extends JpaRepository<City, Integer> {
+public interface CityRepository extends JpaRepository<City, Long> {
     Optional<City> findByNameAndState(String name, State state);
 }

--- a/src/main/java/com/management/company/controller/CompanyController.java
+++ b/src/main/java/com/management/company/controller/CompanyController.java
@@ -7,11 +7,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/companies")
+@Tag(name = "Organizational")
 public class CompanyController {
 
     private final PersonService personService;
@@ -21,6 +24,7 @@ public class CompanyController {
     }
 
     @GetMapping("/{companyId}/persons")
+    @Operation(summary = "Finds all persons for a company")
     public ResponseEntity<List<PersonDTO>> findPersonsByCompanyId(@PathVariable Long companyId) {
         return ResponseEntity.ok(personService.findPersonsByCompanyId(companyId));
     }

--- a/src/main/java/com/management/company/controller/CompanyController.java
+++ b/src/main/java/com/management/company/controller/CompanyController.java
@@ -21,7 +21,7 @@ public class CompanyController {
     }
 
     @GetMapping("/{companyId}/persons")
-    public ResponseEntity<List<PersonDTO>> findPersonsByCompanyId(@PathVariable Integer companyId) {
+    public ResponseEntity<List<PersonDTO>> findPersonsByCompanyId(@PathVariable Long companyId) {
         return ResponseEntity.ok(personService.findPersonsByCompanyId(companyId));
     }
 }

--- a/src/main/java/com/management/company/model/Company.java
+++ b/src/main/java/com/management/company/model/Company.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public class Company {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     private String document;
 
@@ -39,11 +39,11 @@ public class Company {
 
     // Getters and Setters
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/company/model/CompanyPartner.java
+++ b/src/main/java/com/management/company/model/CompanyPartner.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public class CompanyPartner {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fk_company", nullable = false)
@@ -29,11 +29,11 @@ public class CompanyPartner {
 
     // Getters and Setters
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/company/repository/CompanyPartnerRepository.java
+++ b/src/main/java/com/management/company/repository/CompanyPartnerRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface CompanyPartnerRepository extends JpaRepository<CompanyPartner, Integer> {
-    List<CompanyPartner> findByCompanyId(Integer companyId);
+public interface CompanyPartnerRepository extends JpaRepository<CompanyPartner, Long> {
+    List<CompanyPartner> findByCompanyId(Long companyId);
 }

--- a/src/main/java/com/management/company/repository/CompanyRepository.java
+++ b/src/main/java/com/management/company/repository/CompanyRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CompanyRepository extends JpaRepository<Company, Integer> {
+public interface CompanyRepository extends JpaRepository<Company, Long> {
 }

--- a/src/main/java/com/management/config/SpringDocConfig.java
+++ b/src/main/java/com/management/config/SpringDocConfig.java
@@ -1,0 +1,20 @@
+package com.management.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SpringDocConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Construction Management System - API v1.0.0 (Core)"))
+                .servers(List.of(new Server().url("/api/v1")));
+    }
+}

--- a/src/main/java/com/management/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/management/exception/ResourceNotFoundException.java
@@ -1,0 +1,12 @@
+package com.management.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/management/person/controller/PersonController.java
+++ b/src/main/java/com/management/person/controller/PersonController.java
@@ -11,11 +11,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/persons")
+@Tag(name = "Organizational")
 public class PersonController {
 
     private final PersonService personService;
@@ -25,17 +28,20 @@ public class PersonController {
     }
 
     @PostMapping
+    @Operation(summary = "Creates a new person")
     public ResponseEntity<PersonDTO> createPerson(@RequestBody PersonCreateDTO createDTO) {
         PersonDTO createdPerson = personService.createPerson(createDTO);
         return new ResponseEntity<>(createdPerson, HttpStatus.CREATED);
     }
 
     @GetMapping
+    @Operation(summary = "Finds all persons")
     public ResponseEntity<List<PersonDTO>> findAll() {
         return ResponseEntity.ok(personService.findAll());
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Finds a person by ID")
     public ResponseEntity<PersonDTO> findById(@PathVariable Long id) {
         return ResponseEntity.ok(personService.findById(id));
     }

--- a/src/main/java/com/management/person/controller/PersonController.java
+++ b/src/main/java/com/management/person/controller/PersonController.java
@@ -36,7 +36,7 @@ public class PersonController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<PersonDTO> findById(@PathVariable Integer id) {
+    public ResponseEntity<PersonDTO> findById(@PathVariable Long id) {
         return ResponseEntity.ok(personService.findById(id));
     }
 }

--- a/src/main/java/com/management/person/model/Person.java
+++ b/src/main/java/com/management/person/model/Person.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 public class Person {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @Column(name = "full_name")
     private String fullName;
@@ -49,11 +49,11 @@ public class Person {
     }
 
     // Getters and Setters
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/person/repository/PersonRepository.java
+++ b/src/main/java/com/management/person/repository/PersonRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PersonRepository extends JpaRepository<Person, Integer> {
+public interface PersonRepository extends JpaRepository<Person, Long> {
 }

--- a/src/main/java/com/management/person/service/PersonService.java
+++ b/src/main/java/com/management/person/service/PersonService.java
@@ -108,13 +108,13 @@ public class PersonService {
                 .collect(Collectors.toList());
     }
 
-    public PersonDTO findById(Integer id) {
+    public PersonDTO findById(Long id) {
         Person person = personRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Pessoa não encontrada com o id: " + id));
         return modelMapper.map(person, PersonDTO.class);
     }
 
-    public List<PersonDTO> findPersonsByCompanyId(Integer companyId) {
+    public List<PersonDTO> findPersonsByCompanyId(Long companyId) {
         return companyPartnerRepository.findByCompanyId(companyId)
                 .stream()
                 .map(companyPartner -> modelMapper.map(companyPartner.getPerson(), PersonDTO.class))

--- a/src/main/java/com/management/project/controller/ProjectController.java
+++ b/src/main/java/com/management/project/controller/ProjectController.java
@@ -32,17 +32,17 @@ public class ProjectController {
     }
 
     @GetMapping("/projects/{id}")
-    public ResponseEntity<ProjectResponse> findById(@PathVariable Integer id) {
+    public ResponseEntity<ProjectResponse> findById(@PathVariable Long id) {
         return ResponseEntity.ok(projectService.findById(id));
     }
 
     @GetMapping("/companies/{companyId}/projects")
-    public ResponseEntity<List<ProjectResponse>> findByCompanyId(@PathVariable Integer companyId) {
+    public ResponseEntity<List<ProjectResponse>> findByCompanyId(@PathVariable Long companyId) {
         return ResponseEntity.ok(projectService.findByCompanyId(companyId));
     }
 
     @GetMapping("/persons/{personId}/projects")
-    public ResponseEntity<List<ProjectResponse>> findByPersonId(@PathVariable Integer personId) {
+    public ResponseEntity<List<ProjectResponse>> findByPersonId(@PathVariable Long personId) {
         return ResponseEntity.ok(projectService.findByPersonId(personId));
     }
 }

--- a/src/main/java/com/management/project/controller/ProjectController.java
+++ b/src/main/java/com/management/project/controller/ProjectController.java
@@ -8,11 +8,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api")
+@Tag(name = "Projects")
 public class ProjectController {
 
     private final ProjectService projectService;
@@ -22,16 +25,19 @@ public class ProjectController {
     }
 
     @PostMapping("/projects")
+    @Operation(summary = "Creates a new project (CPF or CNPJ)")
     public ResponseEntity<ProjectResponse> create(@RequestBody @Valid ProjectCreateRequest request) {
         return ResponseEntity.ok(projectService.create(request));
     }
 
     @GetMapping("/projects")
+    @Operation(summary = "Finds all projects")
     public ResponseEntity<Page<ProjectResponse>> findAll(Pageable pageable) {
         return ResponseEntity.ok(projectService.findAll(pageable));
     }
 
     @GetMapping("/projects/{id}")
+    @Operation(summary = "Finds a project by ID")
     public ResponseEntity<ProjectResponse> findById(@PathVariable Long id) {
         return ResponseEntity.ok(projectService.findById(id));
     }

--- a/src/main/java/com/management/project/dto/ProjectCreateRequest.java
+++ b/src/main/java/com/management/project/dto/ProjectCreateRequest.java
@@ -1,11 +1,13 @@
 package com.management.project.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 import java.time.LocalDate;
 
 @Data
+@Schema(description = "The request must include either fkCompanyId or fkOwnerPersonId, but not both.")
 public class ProjectCreateRequest {
 
     @NotBlank

--- a/src/main/java/com/management/project/dto/ProjectCreateRequest.java
+++ b/src/main/java/com/management/project/dto/ProjectCreateRequest.java
@@ -17,10 +17,10 @@ public class ProjectCreateRequest {
     private LocalDate endDate;
 
     // Empresa (CNPJ)
-    private Integer companyId;
+    private Long companyId;
 
     // Pessoa física (CPF)
-    private Integer ownerPersonId;
+    private Long ownerPersonId;
 
-    private Integer addressId;
+    private Long addressId;
 }

--- a/src/main/java/com/management/project/dto/ProjectResponse.java
+++ b/src/main/java/com/management/project/dto/ProjectResponse.java
@@ -6,14 +6,14 @@ import java.time.LocalDateTime;
 
 @Data
 public class ProjectResponse {
-    private Integer id;
+    private Long id;
     private String name;
     private String description;
     private LocalDate startDate;
     private LocalDate endDate;
-    private Integer companyId;
-    private Integer ownerPersonId;
-    private Integer addressId;
+    private Long companyId;
+    private Long ownerPersonId;
+    private Long addressId;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/management/project/model/Project.java
+++ b/src/main/java/com/management/project/model/Project.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 public class Project {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     private String name;
     private String description;
@@ -54,11 +54,11 @@ public class Project {
 
     // Getters and Setters
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/project/model/ProjectMember.java
+++ b/src/main/java/com/management/project/model/ProjectMember.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public class ProjectMember {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fk_project", nullable = false)
@@ -40,11 +40,11 @@ public class ProjectMember {
 
     // Getters and Setters
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/management/project/repository/ProjectMemberRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Integer> {
-    List<ProjectMember> findByPersonId(Integer personId);
+public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
+    List<ProjectMember> findByPersonId(Long personId);
 }

--- a/src/main/java/com/management/project/repository/ProjectRepository.java
+++ b/src/main/java/com/management/project/repository/ProjectRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProjectRepository extends JpaRepository<Project, Integer> {
-    List<Project> findByCompanyId(Integer companyId);
-    List<Project> findByOwnerPersonId(Integer personId);
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+    List<Project> findByCompanyId(Long companyId);
+    List<Project> findByOwnerPersonId(Long personId);
 }

--- a/src/main/java/com/management/project/service/ProjectService.java
+++ b/src/main/java/com/management/project/service/ProjectService.java
@@ -103,14 +103,14 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public ProjectResponse findById(Integer id) {
+    public ProjectResponse findById(Long id) {
         Project project = projectRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + id));
         return projectMapper.toResponse(project);
     }
 
     @Transactional(readOnly = true)
-    public List<ProjectResponse> findByCompanyId(Integer companyId) {
+    public List<ProjectResponse> findByCompanyId(Long companyId) {
         if (!companyRepository.existsById(companyId)) {
             throw new ResourceNotFoundException("Company not found with id: " + companyId);
         }
@@ -118,7 +118,7 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProjectResponse> findByPersonId(Integer personId) {
+    public List<ProjectResponse> findByPersonId(Long personId) {
         if (!personRepository.existsById(personId)) {
             throw new ResourceNotFoundException("Person not found with id: " + personId);
         }

--- a/src/main/java/com/management/projectoccurrence/controller/ProjectOccurrenceController.java
+++ b/src/main/java/com/management/projectoccurrence/controller/ProjectOccurrenceController.java
@@ -8,11 +8,14 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api")
+@Tag(name = "Rastreability")
 public class ProjectOccurrenceController {
 
     private final ProjectOccurrenceService projectOccurrenceService;
@@ -22,26 +25,31 @@ public class ProjectOccurrenceController {
     }
 
     @PostMapping("/occurrences")
+    @Operation(summary = "Registers a new occurrence")
     public ResponseEntity<ProjectOccurrenceResponse> create(@Valid @RequestBody ProjectOccurrenceCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(projectOccurrenceService.create(request));
     }
 
     @GetMapping("/occurrences/{id}")
+    @Operation(summary = "Finds an occurrence by ID")
     public ResponseEntity<ProjectOccurrenceResponse> getById(@PathVariable Long id) {
         return ResponseEntity.ok(projectOccurrenceService.findById(id));
     }
 
     @GetMapping("/projects/{projectId}/occurrences")
+    @Operation(summary = "Finds all occurrences for a project")
     public ResponseEntity<List<ProjectOccurrenceResponse>> listByProject(@PathVariable Long projectId) {
         return ResponseEntity.ok(projectOccurrenceService.listByProject(projectId));
     }
 
     @PutMapping("/occurrences/{id}")
+    @Operation(summary = "Updates an occurrence")
     public ResponseEntity<ProjectOccurrenceResponse> update(@PathVariable Long id, @Valid @RequestBody ProjectOccurrenceUpdateRequest request) {
         return ResponseEntity.ok(projectOccurrenceService.update(id, request));
     }
 
     @DeleteMapping("/occurrences/{id}")
+    @Operation(summary = "Deletes an occurrence")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         projectOccurrenceService.delete(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/management/projectoccurrence/controller/ProjectOccurrenceController.java
+++ b/src/main/java/com/management/projectoccurrence/controller/ProjectOccurrenceController.java
@@ -27,22 +27,22 @@ public class ProjectOccurrenceController {
     }
 
     @GetMapping("/occurrences/{id}")
-    public ResponseEntity<ProjectOccurrenceResponse> getById(@PathVariable Integer id) {
+    public ResponseEntity<ProjectOccurrenceResponse> getById(@PathVariable Long id) {
         return ResponseEntity.ok(projectOccurrenceService.findById(id));
     }
 
     @GetMapping("/projects/{projectId}/occurrences")
-    public ResponseEntity<List<ProjectOccurrenceResponse>> listByProject(@PathVariable Integer projectId) {
+    public ResponseEntity<List<ProjectOccurrenceResponse>> listByProject(@PathVariable Long projectId) {
         return ResponseEntity.ok(projectOccurrenceService.listByProject(projectId));
     }
 
     @PutMapping("/occurrences/{id}")
-    public ResponseEntity<ProjectOccurrenceResponse> update(@PathVariable Integer id, @Valid @RequestBody ProjectOccurrenceUpdateRequest request) {
+    public ResponseEntity<ProjectOccurrenceResponse> update(@PathVariable Long id, @Valid @RequestBody ProjectOccurrenceUpdateRequest request) {
         return ResponseEntity.ok(projectOccurrenceService.update(id, request));
     }
 
     @DeleteMapping("/occurrences/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
         projectOccurrenceService.delete(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/management/projectoccurrence/dto/ProjectOccurrenceCreateRequest.java
+++ b/src/main/java/com/management/projectoccurrence/dto/ProjectOccurrenceCreateRequest.java
@@ -2,52 +2,22 @@ package com.management.projectoccurrence.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
 import java.time.LocalDate;
 
+@Data
 public class ProjectOccurrenceCreateRequest {
 
     @NotNull
-    private Integer projectId;
+    private Long projectId;
 
     @NotNull
-    private Integer personId;
+    private Long personId;
 
     @NotNull
     private LocalDate occurrenceDate;
 
     @NotBlank
     private String description;
-
-    // Getters and Setters
-    public Integer getProjectId() {
-        return projectId;
-    }
-
-    public void setProjectId(Integer projectId) {
-        this.projectId = projectId;
-    }
-
-    public Integer getPersonId() {
-        return personId;
-    }
-
-    public void setPersonId(Integer personId) {
-        this.personId = personId;
-    }
-
-    public LocalDate getOccurrenceDate() {
-        return occurrenceDate;
-    }
-
-    public void setOccurrenceDate(LocalDate occurrenceDate) {
-        this.occurrenceDate = occurrenceDate;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
 }

--- a/src/main/java/com/management/projectoccurrence/dto/ProjectOccurrenceResponse.java
+++ b/src/main/java/com/management/projectoccurrence/dto/ProjectOccurrenceResponse.java
@@ -1,72 +1,18 @@
 package com.management.projectoccurrence.dto;
 
+import lombok.Data;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Data
 public class ProjectOccurrenceResponse {
 
-    private Integer id;
-    private Integer projectId;
-    private Integer personId;
+    private Long id;
+    private Long projectId;
+    private Long personId;
     private LocalDate occurrenceDate;
     private String description;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-
-    // Getters and Setters
-    public Integer getId() {
-        return id;
-    }
-
-    public void setId(Integer id) {
-        this.id = id;
-    }
-
-    public Integer getProjectId() {
-        return projectId;
-    }
-
-    public void setProjectId(Integer projectId) {
-        this.projectId = projectId;
-    }
-
-    public Integer getPersonId() {
-        return personId;
-    }
-
-    public void setPersonId(Integer personId) {
-        this.personId = personId;
-    }
-
-    public LocalDate getOccurrenceDate() {
-        return occurrenceDate;
-    }
-
-    public void setOccurrenceDate(LocalDate occurrenceDate) {
-        this.occurrenceDate = occurrenceDate;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(LocalDateTime createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public LocalDateTime getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
-    }
 }

--- a/src/main/java/com/management/projectoccurrence/model/ProjectOccurrence.java
+++ b/src/main/java/com/management/projectoccurrence/model/ProjectOccurrence.java
@@ -12,7 +12,7 @@ public class ProjectOccurrence {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fk_project", nullable = false)
@@ -46,11 +46,11 @@ public class ProjectOccurrence {
     }
 
     // Getters and Setters
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/projectoccurrence/repository/ProjectOccurrenceRepository.java
+++ b/src/main/java/com/management/projectoccurrence/repository/ProjectOccurrenceRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProjectOccurrenceRepository extends JpaRepository<ProjectOccurrence, Integer> {
+public interface ProjectOccurrenceRepository extends JpaRepository<ProjectOccurrence, Long> {
 
-    List<ProjectOccurrence> findByProjectId(Integer projectId);
+    List<ProjectOccurrence> findByProjectId(Long projectId);
 }

--- a/src/main/java/com/management/projectoccurrence/service/ProjectOccurrenceService.java
+++ b/src/main/java/com/management/projectoccurrence/service/ProjectOccurrenceService.java
@@ -50,7 +50,7 @@ public class ProjectOccurrenceService {
     }
 
     @Transactional
-    public ProjectOccurrenceResponse update(Integer id, ProjectOccurrenceUpdateRequest request) {
+    public ProjectOccurrenceResponse update(Long id, ProjectOccurrenceUpdateRequest request) {
         ProjectOccurrence occurrence = projectOccurrenceRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Occurrence not found with id: " + id));
 
@@ -65,7 +65,7 @@ public class ProjectOccurrenceService {
     }
 
     @Transactional
-    public void delete(Integer id) {
+    public void delete(Long id) {
         if (!projectOccurrenceRepository.existsById(id)) {
             throw new ResourceNotFoundException("Occurrence not found with id: " + id);
         }
@@ -73,7 +73,7 @@ public class ProjectOccurrenceService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProjectOccurrenceResponse> listByProject(Integer projectId) {
+    public List<ProjectOccurrenceResponse> listByProject(Long projectId) {
         if (!projectRepository.existsById(projectId)) {
             throw new ResourceNotFoundException("Project not found with id: " + projectId);
         }
@@ -82,7 +82,7 @@ public class ProjectOccurrenceService {
                 .collect(Collectors.toList());
     }
      @Transactional(readOnly = true)
-    public ProjectOccurrenceResponse findById(Integer id) {
+    public ProjectOccurrenceResponse findById(Long id) {
         ProjectOccurrence occurrence = projectOccurrenceRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Occurrence not found with id: " + id));
         return projectOccurrenceMapper.toResponse(occurrence);

--- a/src/main/java/com/management/resource/controller/ProjectResourceController.java
+++ b/src/main/java/com/management/resource/controller/ProjectResourceController.java
@@ -9,37 +9,45 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Resources")
 public class ProjectResourceController {
 
     private final ProjectResourceService resourceService;
 
     @PostMapping("/resources")
+    @Operation(summary = "Creates a new resource")
     public ResponseEntity<ProjectResourceResponse> create(@Valid @RequestBody ProjectResourceCreateRequest request) {
         ProjectResourceResponse createdResource = resourceService.create(request);
         return new ResponseEntity<>(createdResource, HttpStatus.CREATED);
     }
 
     @GetMapping("/resources/{id}")
+    @Operation(summary = "Finds a resource by ID")
     public ResponseEntity<ProjectResourceResponse> getById(@PathVariable Long id) {
         return ResponseEntity.ok(resourceService.findById(id));
     }
 
     @GetMapping("/projects/{projectId}/resources")
+    @Operation(summary = "Finds all resources for a project")
     public ResponseEntity<List<ProjectResourceResponse>> getByProject(@PathVariable Long projectId) {
         return ResponseEntity.ok(resourceService.listByProject(projectId));
     }
 
     @PutMapping("/resources/{id}")
+    @Operation(summary = "Updates a resource")
     public ResponseEntity<ProjectResourceResponse> update(@PathVariable Long id, @Valid @RequestBody ProjectResourceUpdateRequest request) {
         return ResponseEntity.ok(resourceService.update(id, request));
     }
 
     @DeleteMapping("/resources/{id}")
+    @Operation(summary = "Deletes a resource")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         resourceService.delete(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/management/resource/controller/ProjectResourceController.java
+++ b/src/main/java/com/management/resource/controller/ProjectResourceController.java
@@ -25,22 +25,22 @@ public class ProjectResourceController {
     }
 
     @GetMapping("/resources/{id}")
-    public ResponseEntity<ProjectResourceResponse> getById(@PathVariable Integer id) {
+    public ResponseEntity<ProjectResourceResponse> getById(@PathVariable Long id) {
         return ResponseEntity.ok(resourceService.findById(id));
     }
 
     @GetMapping("/projects/{projectId}/resources")
-    public ResponseEntity<List<ProjectResourceResponse>> getByProject(@PathVariable Integer projectId) {
+    public ResponseEntity<List<ProjectResourceResponse>> getByProject(@PathVariable Long projectId) {
         return ResponseEntity.ok(resourceService.listByProject(projectId));
     }
 
     @PutMapping("/resources/{id}")
-    public ResponseEntity<ProjectResourceResponse> update(@PathVariable Integer id, @Valid @RequestBody ProjectResourceUpdateRequest request) {
+    public ResponseEntity<ProjectResourceResponse> update(@PathVariable Long id, @Valid @RequestBody ProjectResourceUpdateRequest request) {
         return ResponseEntity.ok(resourceService.update(id, request));
     }
 
     @DeleteMapping("/resources/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
         resourceService.delete(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/management/resource/dto/ProjectResourceCreateRequest.java
+++ b/src/main/java/com/management/resource/dto/ProjectResourceCreateRequest.java
@@ -10,7 +10,7 @@ import java.math.BigDecimal;
 public class ProjectResourceCreateRequest {
 
     @NotNull(message = "O ID do projeto é obrigatório")
-    private Integer projectId;
+    private Long projectId;
 
     @NotBlank(message = "O nome do recurso é obrigatório")
     private String name;

--- a/src/main/java/com/management/resource/dto/ProjectResourceResponse.java
+++ b/src/main/java/com/management/resource/dto/ProjectResourceResponse.java
@@ -6,8 +6,8 @@ import java.time.LocalDateTime;
 
 @Data
 public class ProjectResourceResponse {
-    private Integer id;
-    private Integer projectId;
+    private Long id;
+    private Long projectId;
     private String name;
     private String unit;
     private BigDecimal quantity;

--- a/src/main/java/com/management/resource/model/ProjectResource.java
+++ b/src/main/java/com/management/resource/model/ProjectResource.java
@@ -13,7 +13,7 @@ public class ProjectResource {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fk_project", nullable = false)

--- a/src/main/java/com/management/resource/repository/ProjectResourceRepository.java
+++ b/src/main/java/com/management/resource/repository/ProjectResourceRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProjectResourceRepository extends JpaRepository<ProjectResource, Integer> {
-    List<ProjectResource> findByProjectId(Integer projectId);
+public interface ProjectResourceRepository extends JpaRepository<ProjectResource, Long> {
+    List<ProjectResource> findByProjectId(Long projectId);
 }

--- a/src/main/java/com/management/resource/service/ProjectResourceService.java
+++ b/src/main/java/com/management/resource/service/ProjectResourceService.java
@@ -41,7 +41,7 @@ public class ProjectResourceService {
     }
 
     @Transactional
-    public ProjectResourceResponse update(Integer id, @Valid ProjectResourceUpdateRequest request) {
+    public ProjectResourceResponse update(Long id, @Valid ProjectResourceUpdateRequest request) {
         ProjectResource resource = resourceRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Recurso não encontrado com o id: " + id));
 
@@ -60,20 +60,20 @@ public class ProjectResourceService {
     }
 
     @Transactional
-    public void delete(Integer id) {
+    public void delete(Long id) {
         if (!resourceRepository.existsById(id)) {
             throw new ResourceNotFoundException("Recurso não encontrado com o id: " + id);
         }
         resourceRepository.deleteById(id);
     }
 
-    public ProjectResourceResponse findById(Integer id) {
+    public ProjectResourceResponse findById(Long id) {
         ProjectResource resource = resourceRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Recurso não encontrado com o id: " + id));
         return resourceMapper.toResponse(resource);
     }
 
-    public List<ProjectResourceResponse> listByProject(Integer projectId) {
+    public List<ProjectResourceResponse> listByProject(Long projectId) {
         if (!projectRepository.existsById(projectId)) {
             throw new ResourceNotFoundException("Projeto não encontrado com o id: " + projectId);
         }

--- a/src/main/java/com/management/role/model/Role.java
+++ b/src/main/java/com/management/role/model/Role.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 public class Role {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @Column(unique = true, nullable = false)
     private String name;
@@ -33,11 +33,11 @@ public class Role {
     }
 
     // Getters and Setters
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/state/dto/StateResponseDTO.java
+++ b/src/main/java/com/management/state/dto/StateResponseDTO.java
@@ -1,0 +1,10 @@
+package com.management.state.dto;
+
+import lombok.Data;
+
+@Data
+public class StateResponseDTO {
+    private Long id;
+    private String name;
+    private String uf;
+}

--- a/src/main/java/com/management/task/controller/ProjectTaskController.java
+++ b/src/main/java/com/management/task/controller/ProjectTaskController.java
@@ -9,40 +9,48 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Tasks")
 public class ProjectTaskController {
 
     private final ProjectTaskService taskService;
 
     @PostMapping("/tasks")
+    @Operation(summary = "Creates a new task")
     public ResponseEntity<ProjectTaskResponse> createTask(@Valid @RequestBody ProjectTaskCreateRequest request) {
         ProjectTaskResponse createdTask = taskService.createTask(request);
         return new ResponseEntity<>(createdTask, HttpStatus.CREATED);
     }
 
     @GetMapping("/tasks/{id}")
+    @Operation(summary = "Finds a task by ID")
     public ResponseEntity<ProjectTaskResponse> getTaskById(@PathVariable Long id) {
         ProjectTaskResponse task = taskService.findTaskById(id);
         return ResponseEntity.ok(task);
     }
 
     @GetMapping("/projects/{projectId}/tasks")
+    @Operation(summary = "Finds all tasks for a project")
     public ResponseEntity<List<ProjectTaskResponse>> getTasksByProject(@PathVariable Long projectId) {
         List<ProjectTaskResponse> tasks = taskService.listByProject(projectId);
         return ResponseEntity.ok(tasks);
     }
 
     @PutMapping("/tasks/{id}")
+    @Operation(summary = "Updates a task")
     public ResponseEntity<ProjectTaskResponse> updateTask(@PathVariable Long id, @Valid @RequestBody ProjectTaskUpdateRequest request) {
         ProjectTaskResponse updatedTask = taskService.updateTask(id, request);
         return ResponseEntity.ok(updatedTask);
     }
 
     @DeleteMapping("/tasks/{id}")
+    @Operation(summary = "Deletes a task")
     public ResponseEntity<Void> deleteTask(@PathVariable Long id) {
         taskService.deleteTask(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/management/task/controller/ProjectTaskController.java
+++ b/src/main/java/com/management/task/controller/ProjectTaskController.java
@@ -25,25 +25,25 @@ public class ProjectTaskController {
     }
 
     @GetMapping("/tasks/{id}")
-    public ResponseEntity<ProjectTaskResponse> getTaskById(@PathVariable Integer id) {
+    public ResponseEntity<ProjectTaskResponse> getTaskById(@PathVariable Long id) {
         ProjectTaskResponse task = taskService.findTaskById(id);
         return ResponseEntity.ok(task);
     }
 
     @GetMapping("/projects/{projectId}/tasks")
-    public ResponseEntity<List<ProjectTaskResponse>> getTasksByProject(@PathVariable Integer projectId) {
+    public ResponseEntity<List<ProjectTaskResponse>> getTasksByProject(@PathVariable Long projectId) {
         List<ProjectTaskResponse> tasks = taskService.listByProject(projectId);
         return ResponseEntity.ok(tasks);
     }
 
     @PutMapping("/tasks/{id}")
-    public ResponseEntity<ProjectTaskResponse> updateTask(@PathVariable Integer id, @Valid @RequestBody ProjectTaskUpdateRequest request) {
+    public ResponseEntity<ProjectTaskResponse> updateTask(@PathVariable Long id, @Valid @RequestBody ProjectTaskUpdateRequest request) {
         ProjectTaskResponse updatedTask = taskService.updateTask(id, request);
         return ResponseEntity.ok(updatedTask);
     }
 
     @DeleteMapping("/tasks/{id}")
-    public ResponseEntity<Void> deleteTask(@PathVariable Integer id) {
+    public ResponseEntity<Void> deleteTask(@PathVariable Long id) {
         taskService.deleteTask(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/management/task/dto/ProjectTaskCreateRequest.java
+++ b/src/main/java/com/management/task/dto/ProjectTaskCreateRequest.java
@@ -16,9 +16,9 @@ public class ProjectTaskCreateRequest {
     private LocalDate dueDate;
 
     @NotNull(message = "O ID do projeto é obrigatório")
-    private Integer projectId;
+    private Long projectId;
 
-    private Integer responsibleId;
+    private Long responsibleId;
 
-    private Integer parentId;
+    private Long parentId;
 }

--- a/src/main/java/com/management/task/dto/ProjectTaskResponse.java
+++ b/src/main/java/com/management/task/dto/ProjectTaskResponse.java
@@ -6,14 +6,14 @@ import java.time.LocalDateTime;
 
 @Data
 public class ProjectTaskResponse {
-    private Integer id;
+    private Long id;
     private String title;
     private String description;
     private String status;
     private LocalDate dueDate;
-    private Integer projectId;
-    private Integer responsibleId;
-    private Integer parentId;
+    private Long projectId;
+    private Long responsibleId;
+    private Long parentId;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/management/task/dto/ProjectTaskUpdateRequest.java
+++ b/src/main/java/com/management/task/dto/ProjectTaskUpdateRequest.java
@@ -9,5 +9,5 @@ public class ProjectTaskUpdateRequest {
     private String description;
     private String status;
     private LocalDate dueDate;
-    private Integer responsibleId;
+    private Long responsibleId;
 }

--- a/src/main/java/com/management/task/model/ProjectTask.java
+++ b/src/main/java/com/management/task/model/ProjectTask.java
@@ -14,7 +14,7 @@ public class ProjectTask {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @Column(nullable = false)
     private String title;

--- a/src/main/java/com/management/task/repository/ProjectTaskRepository.java
+++ b/src/main/java/com/management/task/repository/ProjectTaskRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProjectTaskRepository extends JpaRepository<ProjectTask, Integer> {
-    List<ProjectTask> findByProjectId(Integer projectId);
+public interface ProjectTaskRepository extends JpaRepository<ProjectTask, Long> {
+    List<ProjectTask> findByProjectId(Long projectId);
 }

--- a/src/main/java/com/management/task/service/ProjectTaskService.java
+++ b/src/main/java/com/management/task/service/ProjectTaskService.java
@@ -56,7 +56,7 @@ public class ProjectTaskService {
     }
 
     @Transactional
-    public ProjectTaskResponse updateTask(Integer id, @Valid ProjectTaskUpdateRequest request) {
+    public ProjectTaskResponse updateTask(Long id, @Valid ProjectTaskUpdateRequest request) {
         ProjectTask task = taskRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Tarefa não encontrada com o id: " + id));
 
@@ -82,7 +82,7 @@ public class ProjectTaskService {
         return taskMapper.toResponse(updatedTask);
     }
 
-    public List<ProjectTaskResponse> listByProject(Integer projectId) {
+    public List<ProjectTaskResponse> listByProject(Long projectId) {
         if (!projectRepository.existsById(projectId)) {
             throw new ResourceNotFoundException("Projeto não encontrado com o id: " + projectId);
         }
@@ -91,14 +91,14 @@ public class ProjectTaskService {
                 .collect(Collectors.toList());
     }
 
-    public ProjectTaskResponse findTaskById(Integer id) {
+    public ProjectTaskResponse findTaskById(Long id) {
         ProjectTask task = taskRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Tarefa não encontrada com o id: " + id));
         return taskMapper.toResponse(task);
     }
 
     @Transactional
-    public void deleteTask(Integer id) {
+    public void deleteTask(Long id) {
         if (!taskRepository.existsById(id)) {
             throw new ResourceNotFoundException("Tarefa não encontrada com o id: " + id);
         }

--- a/src/test/java/com/management/address/controller/ProjectAddressControllerTest.java
+++ b/src/test/java/com/management/address/controller/ProjectAddressControllerTest.java
@@ -60,7 +60,7 @@ public class ProjectAddressControllerTest {
     void testCreateProjectAddress() throws Exception {
         when(projectAddressService.createProjectAddress(anyLong(), any(ProjectAddressRequestDTO.class))).thenReturn(responseDTO);
 
-        mockMvc.perform(post("/api/projects/1/address")
+        mockMvc.perform(post("/api/projects/1/addresses")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDTO)))
                 .andExpect(status().isCreated())
@@ -71,7 +71,7 @@ public class ProjectAddressControllerTest {
     void testGetProjectAddress() throws Exception {
         when(projectAddressService.getProjectAddress(anyLong())).thenReturn(responseDTO);
 
-        mockMvc.perform(get("/api/projects/1/address"))
+        mockMvc.perform(get("/api/projects/1/addresses"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.street").value("Test Street"));
     }
@@ -80,7 +80,7 @@ public class ProjectAddressControllerTest {
     void testUpdateProjectAddress() throws Exception {
         when(projectAddressService.updateProjectAddress(anyLong(), any(ProjectAddressRequestDTO.class))).thenReturn(responseDTO);
 
-        mockMvc.perform(put("/api/projects/1/address")
+        mockMvc.perform(put("/api/projects/1/addresses")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDTO)))
                 .andExpect(status().isOk())
@@ -91,7 +91,7 @@ public class ProjectAddressControllerTest {
     void testDeleteProjectAddress() throws Exception {
         doNothing().when(projectAddressService).deleteProjectAddress(anyLong());
 
-        mockMvc.perform(delete("/api/projects/1/address"))
+        mockMvc.perform(delete("/api/projects/1/addresses"))
                 .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/management/address/controller/ProjectAddressControllerTest.java
+++ b/src/test/java/com/management/address/controller/ProjectAddressControllerTest.java
@@ -1,0 +1,97 @@
+package com.management.address.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.management.address.dto.ProjectAddressRequestDTO;
+import com.management.address.dto.ProjectAddressResponseDTO;
+import com.management.address.service.ProjectAddressService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class ProjectAddressControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private ProjectAddressService projectAddressService;
+
+    @InjectMocks
+    private ProjectAddressController projectAddressController;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    private ProjectAddressRequestDTO requestDTO;
+    private ProjectAddressResponseDTO responseDTO;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(projectAddressController).build();
+        requestDTO = new ProjectAddressRequestDTO();
+        requestDTO.setStreet("Test Street");
+        requestDTO.setNumber("123");
+        requestDTO.setNeighborhood("Test Neighborhood");
+        requestDTO.setZipCode("12345-678");
+        requestDTO.setCityId(1L);
+
+        responseDTO = new ProjectAddressResponseDTO();
+        responseDTO.setStreet("Test Street");
+    }
+
+    @Test
+    void testCreateProjectAddress() throws Exception {
+        when(projectAddressService.createProjectAddress(anyLong(), any(ProjectAddressRequestDTO.class))).thenReturn(responseDTO);
+
+        mockMvc.perform(post("/api/projects/1/address")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.street").value("Test Street"));
+    }
+
+    @Test
+    void testGetProjectAddress() throws Exception {
+        when(projectAddressService.getProjectAddress(anyLong())).thenReturn(responseDTO);
+
+        mockMvc.perform(get("/api/projects/1/address"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.street").value("Test Street"));
+    }
+
+    @Test
+    void testUpdateProjectAddress() throws Exception {
+        when(projectAddressService.updateProjectAddress(anyLong(), any(ProjectAddressRequestDTO.class))).thenReturn(responseDTO);
+
+        mockMvc.perform(put("/api/projects/1/address")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.street").value("Test Street"));
+    }
+
+    @Test
+    void testDeleteProjectAddress() throws Exception {
+        doNothing().when(projectAddressService).deleteProjectAddress(anyLong());
+
+        mockMvc.perform(delete("/api/projects/1/address"))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/com/management/address/service/ProjectAddressServiceTest.java
+++ b/src/test/java/com/management/address/service/ProjectAddressServiceTest.java
@@ -1,0 +1,125 @@
+package com.management.address.service;
+
+import com.management.address.dto.ProjectAddressRequestDTO;
+import com.management.address.dto.ProjectAddressResponseDTO;
+import com.management.address.model.Address;
+import com.management.address.repository.AddressRepository;
+import com.management.city.model.City;
+import com.management.city.repository.CityRepository;
+import com.management.exception.ResourceNotFoundException;
+import com.management.project.model.Project;
+import com.management.project.repository.ProjectRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ProjectAddressServiceTest {
+
+    @InjectMocks
+    private ProjectAddressService projectAddressService;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Mock
+    private AddressRepository addressRepository;
+
+    @Mock
+    private CityRepository cityRepository;
+
+    @Spy
+    private ModelMapper modelMapper;
+
+    private Project project;
+    private Address address;
+    private City city;
+    private ProjectAddressRequestDTO requestDTO;
+
+    @BeforeEach
+    void setUp() {
+        city = new City();
+        city.setId(1L);
+        city.setName("Test City");
+
+        address = new Address();
+        address.setId(1L);
+        address.setStreet("Test Street");
+        address.setCity(city);
+
+        project = new Project();
+        project.setId(1L);
+        project.setAddress(address);
+
+        requestDTO = new ProjectAddressRequestDTO();
+        requestDTO.setCityId(1L);
+        requestDTO.setStreet("Test Street");
+    }
+
+    @Test
+    void testCreateProjectAddress() {
+        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+        when(cityRepository.findById(1L)).thenReturn(Optional.of(city));
+        when(projectRepository.save(any(Project.class))).thenReturn(project);
+
+        ProjectAddressResponseDTO responseDTO = projectAddressService.createProjectAddress(1L, requestDTO);
+
+        assertNotNull(responseDTO);
+        assertEquals("Test Street", responseDTO.getStreet());
+        verify(projectRepository, times(1)).save(project);
+    }
+
+    @Test
+    void testGetProjectAddress() {
+        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+
+        ProjectAddressResponseDTO responseDTO = projectAddressService.getProjectAddress(1L);
+
+        assertNotNull(responseDTO);
+        assertEquals("Test Street", responseDTO.getStreet());
+    }
+
+    @Test
+    void testGetProjectAddress_NotFound() {
+        when(projectRepository.findById(1L)).thenReturn(Optional.of(new Project()));
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            projectAddressService.getProjectAddress(1L);
+        });
+    }
+
+    @Test
+    void testUpdateProjectAddress() {
+        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+        when(cityRepository.findById(1L)).thenReturn(Optional.of(city));
+        when(addressRepository.save(any(Address.class))).thenReturn(address);
+
+        ProjectAddressResponseDTO responseDTO = projectAddressService.updateProjectAddress(1L, requestDTO);
+
+        assertNotNull(responseDTO);
+        assertEquals("Test Street", responseDTO.getStreet());
+        verify(addressRepository, times(1)).save(address);
+    }
+
+    @Test
+    void testDeleteProjectAddress() {
+        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+        when(projectRepository.save(any(Project.class))).thenReturn(project);
+
+        projectAddressService.deleteProjectAddress(1L);
+
+        verify(projectRepository, times(1)).save(project);
+        assertNull(project.getAddress());
+    }
+}

--- a/src/test/java/com/management/person/service/PersonServiceTest.java
+++ b/src/test/java/com/management/person/service/PersonServiceTest.java
@@ -54,7 +54,7 @@ class PersonServiceTest {
         createDTO.setCnpj("12345678901234");
 
         Person person = new Person();
-        person.setId(1);
+        person.setId(1L);
 
         CnpjResponseDTO cnpjResponse = new CnpjResponseDTO();
         cnpjResponse.setRazaoSocial("Test Company");
@@ -80,7 +80,7 @@ class PersonServiceTest {
         createDTO.setFullName("Test User");
 
         Person person = new Person();
-        person.setId(1);
+        person.setId(1L);
 
         when(modelMapper.map(any(PersonCreateDTO.class), eq(Person.class))).thenReturn(person);
         when(personRepository.save(any(Person.class))).thenReturn(person);

--- a/src/test/java/com/management/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/management/project/service/ProjectServiceTest.java
@@ -70,8 +70,8 @@ class ProjectServiceTest {
 
     @Test
     void create_shouldThrowBusinessException_whenBothCompanyIdAndOwnerPersonIdAreProvided() {
-        projectCreateRequest.setCompanyId(1);
-        projectCreateRequest.setOwnerPersonId(1);
+        projectCreateRequest.setCompanyId(1L);
+        projectCreateRequest.setOwnerPersonId(1L);
 
         assertThrows(BusinessException.class, () -> projectService.create(projectCreateRequest));
     }
@@ -83,22 +83,22 @@ class ProjectServiceTest {
 
     @Test
     void create_shouldCreateCorporateProject_whenCompanyIdIsProvided() {
-        projectCreateRequest.setCompanyId(1);
+        projectCreateRequest.setCompanyId(1L);
 
         Company company = new Company();
-        company.setId(1);
-        when(companyRepository.findById(1)).thenReturn(Optional.of(company));
+        company.setId(1L);
+        when(companyRepository.findById(1L)).thenReturn(Optional.of(company));
 
         Project project = new Project();
-        project.setId(1);
+        project.setId(1L);
         project.setName(projectCreateRequest.getName());
         project.setCompany(company);
         when(projectRepository.save(any(Project.class))).thenReturn(project);
 
         ProjectResponse projectResponse = new ProjectResponse();
-        projectResponse.setId(1);
+        projectResponse.setId(1L);
         projectResponse.setName("New Project");
-        projectResponse.setCompanyId(1);
+        projectResponse.setCompanyId(1L);
         when(projectMapper.toResponse(any(Project.class))).thenReturn(projectResponse);
 
         ProjectResponse response = projectService.create(projectCreateRequest);
@@ -113,22 +113,22 @@ class ProjectServiceTest {
 
     @Test
     void create_shouldCreatePersonalProjectAndProjectMember_whenOwnerPersonIdIsProvided() {
-        projectCreateRequest.setOwnerPersonId(1);
+        projectCreateRequest.setOwnerPersonId(1L);
 
         Person person = new Person();
-        person.setId(1);
-        when(personRepository.findById(1)).thenReturn(Optional.of(person));
+        person.setId(1L);
+        when(personRepository.findById(1L)).thenReturn(Optional.of(person));
 
         Project project = new Project();
-        project.setId(1);
+        project.setId(1L);
         project.setName(projectCreateRequest.getName());
         project.setOwnerPerson(person);
         when(projectRepository.save(any(Project.class))).thenReturn(project);
 
         ProjectResponse projectResponse = new ProjectResponse();
-        projectResponse.setId(1);
+        projectResponse.setId(1L);
         projectResponse.setName("New Project");
-        projectResponse.setOwnerPersonId(1);
+        projectResponse.setOwnerPersonId(1L);
         when(projectMapper.toResponse(any(Project.class))).thenReturn(projectResponse);
 
         ProjectResponse response = projectService.create(projectCreateRequest);
@@ -143,26 +143,26 @@ class ProjectServiceTest {
 
     @Test
     void create_shouldSetAddress_whenAddressIdIsProvided() {
-        projectCreateRequest.setCompanyId(1);
-        projectCreateRequest.setAddressId(1);
+        projectCreateRequest.setCompanyId(1L);
+        projectCreateRequest.setAddressId(1L);
 
         Company company = new Company();
-        company.setId(1);
-        when(companyRepository.findById(1)).thenReturn(Optional.of(company));
+        company.setId(1L);
+        when(companyRepository.findById(1L)).thenReturn(Optional.of(company));
 
         Address address = new Address();
-        address.setId(1);
-        when(addressRepository.findById(1)).thenReturn(Optional.of(address));
+        address.setId(1L);
+        when(addressRepository.findById(1L)).thenReturn(Optional.of(address));
 
         Project project = new Project();
-        project.setId(1);
+        project.setId(1L);
         project.setName(projectCreateRequest.getName());
         project.setCompany(company);
         project.setAddress(address);
         when(projectRepository.save(any(Project.class))).thenReturn(project);
 
         ProjectResponse projectResponse = new ProjectResponse();
-        projectResponse.setAddressId(1);
+        projectResponse.setAddressId(1L);
         when(projectMapper.toResponse(any(Project.class))).thenReturn(projectResponse);
 
         ProjectResponse response = projectService.create(projectCreateRequest);
@@ -185,14 +185,14 @@ class ProjectServiceTest {
     @Test
     void findById_shouldReturnProject() {
         Project project = new Project();
-        project.setId(1);
-        when(projectRepository.findById(1)).thenReturn(Optional.of(project));
+        project.setId(1L);
+        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
 
         ProjectResponse projectResponse = new ProjectResponse();
-        projectResponse.setId(1);
+        projectResponse.setId(1L);
         when(projectMapper.toResponse(any(Project.class))).thenReturn(projectResponse);
 
-        ProjectResponse response = projectService.findById(1);
+        ProjectResponse response = projectService.findById(1L);
 
         assertNotNull(response);
         assertEquals(1, response.getId());
@@ -200,11 +200,11 @@ class ProjectServiceTest {
 
     @Test
     void findByCompanyId_shouldReturnListOfProjects() {
-        when(companyRepository.existsById(1)).thenReturn(true);
-        when(projectRepository.findByCompanyId(1)).thenReturn(Collections.singletonList(new Project()));
+        when(companyRepository.existsById(1L)).thenReturn(true);
+        when(projectRepository.findByCompanyId(1L)).thenReturn(Collections.singletonList(new Project()));
         when(projectMapper.toResponse(any(List.class))).thenReturn(Collections.singletonList(new ProjectResponse()));
 
-        List<ProjectResponse> response = projectService.findByCompanyId(1);
+        List<ProjectResponse> response = projectService.findByCompanyId(1L);
 
         assertNotNull(response);
         assertEquals(1, response.size());
@@ -212,12 +212,12 @@ class ProjectServiceTest {
 
     @Test
     void findByPersonId_shouldReturnListOfProjects() {
-        when(personRepository.existsById(1)).thenReturn(true);
-        when(projectRepository.findByOwnerPersonId(1)).thenReturn(Collections.singletonList(new Project()));
-        when(projectMemberRepository.findByPersonId(1)).thenReturn(Collections.emptyList());
+        when(personRepository.existsById(1L)).thenReturn(true);
+        when(projectRepository.findByOwnerPersonId(1L)).thenReturn(Collections.singletonList(new Project()));
+        when(projectMemberRepository.findByPersonId(1L)).thenReturn(Collections.emptyList());
         when(projectMapper.toResponse(any(List.class))).thenReturn(Collections.singletonList(new ProjectResponse()));
 
-        List<ProjectResponse> response = projectService.findByPersonId(1);
+        List<ProjectResponse> response = projectService.findByPersonId(1L);
 
         assertNotNull(response);
         assertEquals(1, response.size());

--- a/src/test/java/com/management/projectoccurrence/service/ProjectOccurrenceServiceTest.java
+++ b/src/test/java/com/management/projectoccurrence/service/ProjectOccurrenceServiceTest.java
@@ -61,18 +61,18 @@ class ProjectOccurrenceServiceTest {
     @Test
     void testCreate() {
         ProjectOccurrenceCreateRequest request = new ProjectOccurrenceCreateRequest();
-        request.setProjectId(1);
-        request.setPersonId(1);
+        request.setProjectId(1L);
+        request.setPersonId(1L);
         request.setDescription("Test Description");
         request.setOccurrenceDate(LocalDate.now());
 
         Project project = new Project();
-        project.setId(1);
+        project.setId(1L);
         Person person = new Person();
-        person.setId(1);
+        person.setId(1L);
 
-        when(projectRepository.findById(1)).thenReturn(Optional.of(project));
-        when(personRepository.findById(1)).thenReturn(Optional.of(person));
+        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+        when(personRepository.findById(1L)).thenReturn(Optional.of(person));
         when(projectOccurrenceRepository.save(any(ProjectOccurrence.class))).thenAnswer(i -> i.getArguments()[0]);
 
         ProjectOccurrenceResponse response = projectOccurrenceService.create(request);
@@ -88,21 +88,21 @@ class ProjectOccurrenceServiceTest {
         request.setDescription("Updated Description");
 
         Project project = new Project();
-        project.setId(1);
+        project.setId(1L);
         Person person = new Person();
-        person.setId(1);
+        person.setId(1L);
 
         ProjectOccurrence occurrence = new ProjectOccurrence();
-        occurrence.setId(1);
+        occurrence.setId(1L);
         occurrence.setDescription("Old Description");
         occurrence.setProject(project);
         occurrence.setPerson(person);
 
 
-        when(projectOccurrenceRepository.findById(1)).thenReturn(Optional.of(occurrence));
+        when(projectOccurrenceRepository.findById(1L)).thenReturn(Optional.of(occurrence));
         when(projectOccurrenceRepository.save(any(ProjectOccurrence.class))).thenAnswer(i -> i.getArguments()[0]);
 
-        ProjectOccurrenceResponse response = projectOccurrenceService.update(1, request);
+        ProjectOccurrenceResponse response = projectOccurrenceService.update(1L, request);
 
         assertNotNull(response);
         assertEquals("Updated Description", response.getDescription());
@@ -110,30 +110,30 @@ class ProjectOccurrenceServiceTest {
 
     @Test
     void testDelete() {
-        when(projectOccurrenceRepository.existsById(1)).thenReturn(true);
-        doNothing().when(projectOccurrenceRepository).deleteById(1);
+        when(projectOccurrenceRepository.existsById(1L)).thenReturn(true);
+        doNothing().when(projectOccurrenceRepository).deleteById(1L);
 
-        projectOccurrenceService.delete(1);
+        projectOccurrenceService.delete(1L);
 
-        verify(projectOccurrenceRepository, times(1)).deleteById(1);
+        verify(projectOccurrenceRepository, times(1)).deleteById(1L);
     }
 
     @Test
     void testListByProject() {
         Project project = new Project();
-        project.setId(1);
+        project.setId(1L);
         Person person = new Person();
-        person.setId(1);
+        person.setId(1L);
 
         ProjectOccurrence occurrence = new ProjectOccurrence();
-        occurrence.setId(1);
+        occurrence.setId(1L);
         occurrence.setProject(project);
         occurrence.setPerson(person);
 
-        when(projectRepository.existsById(1)).thenReturn(true);
-        when(projectOccurrenceRepository.findByProjectId(1)).thenReturn(Collections.singletonList(occurrence));
+        when(projectRepository.existsById(1L)).thenReturn(true);
+        when(projectOccurrenceRepository.findByProjectId(1L)).thenReturn(Collections.singletonList(occurrence));
 
-        List<ProjectOccurrenceResponse> response = projectOccurrenceService.listByProject(1);
+        List<ProjectOccurrenceResponse> response = projectOccurrenceService.listByProject(1L);
 
         assertNotNull(response);
         assertFalse(response.isEmpty());
@@ -143,18 +143,18 @@ class ProjectOccurrenceServiceTest {
     @Test
     void testFindById() {
         Project project = new Project();
-        project.setId(1);
+        project.setId(1L);
         Person person = new Person();
-        person.setId(1);
+        person.setId(1L);
 
         ProjectOccurrence occurrence = new ProjectOccurrence();
-        occurrence.setId(1);
+        occurrence.setId(1L);
         occurrence.setProject(project);
         occurrence.setPerson(person);
 
-        when(projectOccurrenceRepository.findById(1)).thenReturn(Optional.of(occurrence));
+        when(projectOccurrenceRepository.findById(1L)).thenReturn(Optional.of(occurrence));
 
-        ProjectOccurrenceResponse response = projectOccurrenceService.findById(1);
+        ProjectOccurrenceResponse response = projectOccurrenceService.findById(1L);
 
         assertNotNull(response);
         assertEquals(1, response.getId());
@@ -163,9 +163,9 @@ class ProjectOccurrenceServiceTest {
     @Test
     void testCreate_ProjectNotFound() {
         ProjectOccurrenceCreateRequest request = new ProjectOccurrenceCreateRequest();
-        request.setProjectId(1);
+        request.setProjectId(1L);
 
-        when(projectRepository.findById(1)).thenReturn(Optional.empty());
+        when(projectRepository.findById(1L)).thenReturn(Optional.empty());
 
         assertThrows(ResourceNotFoundException.class, () -> projectOccurrenceService.create(request));
     }

--- a/src/test/java/com/management/resource/service/ProjectResourceServiceTest.java
+++ b/src/test/java/com/management/resource/service/ProjectResourceServiceTest.java
@@ -37,13 +37,13 @@ class ProjectResourceServiceTest {
         // Arrange
         ProjectResourceCreateRequest request = new ProjectResourceCreateRequest();
         request.setName("New Resource");
-        request.setProjectId(1);
+        request.setProjectId(1L);
 
         Project project = new Project();
         ProjectResource resource = new ProjectResource();
         ProjectResourceResponse response = new ProjectResourceResponse();
 
-        when(projectRepository.findById(1)).thenReturn(Optional.of(project));
+        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
         when(resourceRepository.save(any(ProjectResource.class))).thenReturn(resource);
         when(resourceMapper.toResponse(resource)).thenReturn(response);
 

--- a/src/test/java/com/management/task/service/ProjectTaskServiceTest.java
+++ b/src/test/java/com/management/task/service/ProjectTaskServiceTest.java
@@ -41,16 +41,16 @@ class ProjectTaskServiceTest {
         // Arrange
         ProjectTaskCreateRequest request = new ProjectTaskCreateRequest();
         request.setTitle("New Task");
-        request.setProjectId(1);
-        request.setResponsibleId(1);
+        request.setProjectId(1L);
+        request.setResponsibleId(1L);
 
         Project project = new Project();
         Person person = new Person();
         ProjectTask task = new ProjectTask();
         ProjectTaskResponse response = new ProjectTaskResponse();
 
-        when(projectRepository.findById(1)).thenReturn(Optional.of(project));
-        when(personRepository.findById(1)).thenReturn(Optional.of(person));
+        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+        when(personRepository.findById(1L)).thenReturn(Optional.of(person));
         when(taskRepository.save(any(ProjectTask.class))).thenReturn(task);
         when(taskMapper.toResponse(task)).thenReturn(response);
 


### PR DESCRIPTION
… IDs to Long

This commit introduces the complete CRUD functionality for the Project Address module.

It also refactors all entity primary keys from Integer to Long for better scalability and consistency across the application. This change was applied to all affected models, repositories, DTOs, services, controllers, and tests.

Key changes:
- Added `ProjectAddressController`, `ProjectAddressService`, and `ProjectAddress` DTOs.
- Implemented `create`, `get`, `update`, and `delete` operations for a project's address.
- Updated all entity IDs from `Integer` to `Long`.
- Updated all related tests to use `Long` for IDs.