### PR TITLE
refactor: Revert entity IDs to Integer and fix ProjectAddress CRUD

### DIFF
--- a/src/main/java/com/management/address/controller/ProjectAddressController.java
+++ b/src/main/java/com/management/address/controller/ProjectAddressController.java
@@ -11,6 +11,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/projects/{projectId}/addresses")
 @Tag(name = "Projects")
@@ -21,29 +23,36 @@ public class ProjectAddressController {
 
     @PostMapping
     @Operation(summary = "Creates a new address for a project")
-    public ResponseEntity<ProjectAddressResponseDTO> createProjectAddress(@PathVariable Long projectId, @Valid @RequestBody ProjectAddressRequestDTO requestDTO) {
+    public ResponseEntity<ProjectAddressResponseDTO> createProjectAddress(@PathVariable Integer projectId, @Valid @RequestBody ProjectAddressRequestDTO requestDTO) {
         ProjectAddressResponseDTO responseDTO = projectAddressService.createProjectAddress(projectId, requestDTO);
         return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);
     }
 
     @GetMapping
-    @Operation(summary = "Finds the address for a project")
-    public ResponseEntity<ProjectAddressResponseDTO> getProjectAddress(@PathVariable Long projectId) {
-        ProjectAddressResponseDTO responseDTO = projectAddressService.getProjectAddress(projectId);
+    @Operation(summary = "Finds all addresses for a project")
+    public ResponseEntity<List<ProjectAddressResponseDTO>> getAllProjectAddresses(@PathVariable Integer projectId) {
+        List<ProjectAddressResponseDTO> responseDTO = projectAddressService.getAllProjectAddresses(projectId);
         return ResponseEntity.ok(responseDTO);
     }
 
-    @PutMapping
-    @Operation(summary = "Updates the address for a project")
-    public ResponseEntity<ProjectAddressResponseDTO> updateProjectAddress(@PathVariable Long projectId, @Valid @RequestBody ProjectAddressRequestDTO requestDTO) {
-        ProjectAddressResponseDTO responseDTO = projectAddressService.updateProjectAddress(projectId, requestDTO);
+    @GetMapping("/{addressId}")
+    @Operation(summary = "Finds an address by ID for a project")
+    public ResponseEntity<ProjectAddressResponseDTO> getProjectAddressById(@PathVariable Integer projectId, @PathVariable Integer addressId) {
+        ProjectAddressResponseDTO responseDTO = projectAddressService.getProjectAddressById(projectId, addressId);
         return ResponseEntity.ok(responseDTO);
     }
 
-    @DeleteMapping
-    @Operation(summary = "Deletes the address for a project")
-    public ResponseEntity<Void> deleteProjectAddress(@PathVariable Long projectId) {
-        projectAddressService.deleteProjectAddress(projectId);
+    @PutMapping("/{addressId}")
+    @Operation(summary = "Updates an address for a project")
+    public ResponseEntity<ProjectAddressResponseDTO> updateProjectAddress(@PathVariable Integer projectId, @PathVariable Integer addressId, @Valid @RequestBody ProjectAddressRequestDTO requestDTO) {
+        ProjectAddressResponseDTO responseDTO = projectAddressService.updateProjectAddress(projectId, addressId, requestDTO);
+        return ResponseEntity.ok(responseDTO);
+    }
+
+    @DeleteMapping("/{addressId}")
+    @Operation(summary = "Deletes an address for a project")
+    public ResponseEntity<Void> deleteProjectAddress(@PathVariable Integer projectId, @PathVariable Integer addressId) {
+        projectAddressService.deleteProjectAddress(projectId, addressId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/management/address/dto/ProjectAddressRequestDTO.java
+++ b/src/main/java/com/management/address/dto/ProjectAddressRequestDTO.java
@@ -22,5 +22,5 @@ public class ProjectAddressRequestDTO {
     private String complement;
 
     @NotNull(message = "City ID is mandatory")
-    private Long cityId;
+    private Integer cityId;
 }

--- a/src/main/java/com/management/address/dto/ProjectAddressResponseDTO.java
+++ b/src/main/java/com/management/address/dto/ProjectAddressResponseDTO.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @Data
 public class ProjectAddressResponseDTO {
-    private Long id;
+    private Integer id;
     private String street;
     private String number;
     private String neighborhood;

--- a/src/main/java/com/management/address/model/Address.java
+++ b/src/main/java/com/management/address/model/Address.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public class Address {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Integer id;
 
     private String street;
     private String number;
@@ -30,11 +30,11 @@ public class Address {
     }
 
     // Getters and Setters
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/address/repository/AddressRepository.java
+++ b/src/main/java/com/management/address/repository/AddressRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AddressRepository extends JpaRepository<Address, Long> {
+public interface AddressRepository extends JpaRepository<Address, Integer> {
 }

--- a/src/main/java/com/management/address/service/ProjectAddressService.java
+++ b/src/main/java/com/management/address/service/ProjectAddressService.java
@@ -12,6 +12,9 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 public class ProjectAddressService {
 
@@ -27,7 +30,7 @@ public class ProjectAddressService {
     @Autowired
     private ModelMapper modelMapper;
 
-    public ProjectAddressResponseDTO createProjectAddress(Long projectId, ProjectAddressRequestDTO requestDTO) {
+    public ProjectAddressResponseDTO createProjectAddress(Integer projectId, ProjectAddressRequestDTO requestDTO) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + projectId));
 
@@ -35,32 +38,42 @@ public class ProjectAddressService {
         address.setCity(cityRepository.findById(requestDTO.getCityId())
                 .orElseThrow(() -> new ResourceNotFoundException("City not found with id: " + requestDTO.getCityId())));
 
-        project.setAddress(address);
+        project.getAddresses().add(address);
         projectRepository.save(project);
 
         return modelMapper.map(address, ProjectAddressResponseDTO.class);
     }
 
-    public ProjectAddressResponseDTO getProjectAddress(Long projectId) {
+    public List<ProjectAddressResponseDTO> getAllProjectAddresses(Integer projectId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + projectId));
 
-        if (project.getAddress() == null) {
-            throw new ResourceNotFoundException("Address not found for project with id: " + projectId);
-        }
-
-        return modelMapper.map(project.getAddress(), ProjectAddressResponseDTO.class);
+        return project.getAddresses().stream()
+                .map(address -> modelMapper.map(address, ProjectAddressResponseDTO.class))
+                .collect(Collectors.toList());
     }
 
-    public ProjectAddressResponseDTO updateProjectAddress(Long projectId, ProjectAddressRequestDTO requestDTO) {
+    public ProjectAddressResponseDTO getProjectAddressById(Integer projectId, Integer addressId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + projectId));
 
-        if (project.getAddress() == null) {
-            throw new ResourceNotFoundException("Address not found for project with id: " + projectId);
-        }
+        Address address = project.getAddresses().stream()
+                .filter(a -> a.getId().equals(addressId))
+                .findFirst()
+                .orElseThrow(() -> new ResourceNotFoundException("Address not found with id: " + addressId));
 
-        Address address = project.getAddress();
+        return modelMapper.map(address, ProjectAddressResponseDTO.class);
+    }
+
+    public ProjectAddressResponseDTO updateProjectAddress(Integer projectId, Integer addressId, ProjectAddressRequestDTO requestDTO) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + projectId));
+
+        Address address = project.getAddresses().stream()
+                .filter(a -> a.getId().equals(addressId))
+                .findFirst()
+                .orElseThrow(() -> new ResourceNotFoundException("Address not found with id: " + addressId));
+
         modelMapper.map(requestDTO, address);
         address.setCity(cityRepository.findById(requestDTO.getCityId())
                 .orElseThrow(() -> new ResourceNotFoundException("City not found with id: " + requestDTO.getCityId())));
@@ -70,17 +83,16 @@ public class ProjectAddressService {
         return modelMapper.map(address, ProjectAddressResponseDTO.class);
     }
 
-    public void deleteProjectAddress(Long projectId) {
+    public void deleteProjectAddress(Integer projectId, Integer addressId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + projectId));
 
-        if (project.getAddress() == null) {
-            throw new ResourceNotFoundException("Address not found for project with id: " + projectId);
-        }
+        Address address = project.getAddresses().stream()
+                .filter(a -> a.getId().equals(addressId))
+                .findFirst()
+                .orElseThrow(() -> new ResourceNotFoundException("Address not found with id: " + addressId));
 
-        Address address = project.getAddress();
-        project.setAddress(null);
+        project.getAddresses().remove(address);
         projectRepository.save(project);
-        addressRepository.delete(address);
     }
 }

--- a/src/main/java/com/management/city/dto/CityResponseDTO.java
+++ b/src/main/java/com/management/city/dto/CityResponseDTO.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @Data
 public class CityResponseDTO {
-    private Long id;
+    private Integer id;
     private String name;
     private StateResponseDTO state;
 }

--- a/src/main/java/com/management/city/model/City.java
+++ b/src/main/java/com/management/city/model/City.java
@@ -8,7 +8,7 @@ import jakarta.persistence.*;
 public class City {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Integer id;
 
     @Column(nullable = false)
     private String name;
@@ -18,11 +18,11 @@ public class City {
     private State state;
 
     // Getters and Setters
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/city/model/State.java
+++ b/src/main/java/com/management/city/model/State.java
@@ -7,18 +7,29 @@ import jakarta.persistence.*;
 public class State {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Integer id;
+
+    @Column(unique = true, nullable = false)
+    private String name;
 
     @Column(unique = true, nullable = false)
     private String uf;
 
     // Getters and Setters
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(Integer id) {
         this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public String getUf() {

--- a/src/main/java/com/management/city/repository/CityRepository.java
+++ b/src/main/java/com/management/city/repository/CityRepository.java
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface CityRepository extends JpaRepository<City, Long> {
+public interface CityRepository extends JpaRepository<City, Integer> {
     Optional<City> findByNameAndState(String name, State state);
 }

--- a/src/main/java/com/management/company/controller/CompanyController.java
+++ b/src/main/java/com/management/company/controller/CompanyController.java
@@ -2,13 +2,13 @@ package com.management.company.controller;
 
 import com.management.person.dto.PersonDTO;
 import com.management.person.service.PersonService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 
@@ -25,7 +25,7 @@ public class CompanyController {
 
     @GetMapping("/{companyId}/persons")
     @Operation(summary = "Finds all persons for a company")
-    public ResponseEntity<List<PersonDTO>> findPersonsByCompanyId(@PathVariable Long companyId) {
+    public ResponseEntity<List<PersonDTO>> findPersonsByCompanyId(@PathVariable Integer companyId) {
         return ResponseEntity.ok(personService.findPersonsByCompanyId(companyId));
     }
 }

--- a/src/main/java/com/management/company/model/Company.java
+++ b/src/main/java/com/management/company/model/Company.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public class Company {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Integer id;
 
     private String document;
 
@@ -39,11 +39,11 @@ public class Company {
 
     // Getters and Setters
 
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/company/model/CompanyPartner.java
+++ b/src/main/java/com/management/company/model/CompanyPartner.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public class CompanyPartner {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fk_company", nullable = false)
@@ -29,11 +29,11 @@ public class CompanyPartner {
 
     // Getters and Setters
 
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/company/repository/CompanyPartnerRepository.java
+++ b/src/main/java/com/management/company/repository/CompanyPartnerRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface CompanyPartnerRepository extends JpaRepository<CompanyPartner, Long> {
-    List<CompanyPartner> findByCompanyId(Long companyId);
+public interface CompanyPartnerRepository extends JpaRepository<CompanyPartner, Integer> {
+    List<CompanyPartner> findByCompanyId(Integer companyId);
 }

--- a/src/main/java/com/management/company/repository/CompanyRepository.java
+++ b/src/main/java/com/management/company/repository/CompanyRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CompanyRepository extends JpaRepository<Company, Long> {
+public interface CompanyRepository extends JpaRepository<Company, Integer> {
 }

--- a/src/main/java/com/management/person/controller/PersonController.java
+++ b/src/main/java/com/management/person/controller/PersonController.java
@@ -3,6 +3,7 @@ package com.management.person.controller;
 import com.management.person.dto.PersonCreateDTO;
 import com.management.person.dto.PersonDTO;
 import com.management.person.service.PersonService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 
@@ -42,7 +42,7 @@ public class PersonController {
 
     @GetMapping("/{id}")
     @Operation(summary = "Finds a person by ID")
-    public ResponseEntity<PersonDTO> findById(@PathVariable Long id) {
+    public ResponseEntity<PersonDTO> findById(@PathVariable Integer id) {
         return ResponseEntity.ok(personService.findById(id));
     }
 }

--- a/src/main/java/com/management/person/model/Person.java
+++ b/src/main/java/com/management/person/model/Person.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 public class Person {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Integer id;
 
     @Column(name = "full_name")
     private String fullName;
@@ -49,11 +49,11 @@ public class Person {
     }
 
     // Getters and Setters
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/person/repository/PersonRepository.java
+++ b/src/main/java/com/management/person/repository/PersonRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PersonRepository extends JpaRepository<Person, Long> {
+public interface PersonRepository extends JpaRepository<Person, Integer> {
 }

--- a/src/main/java/com/management/person/service/PersonService.java
+++ b/src/main/java/com/management/person/service/PersonService.java
@@ -108,13 +108,13 @@ public class PersonService {
                 .collect(Collectors.toList());
     }
 
-    public PersonDTO findById(Long id) {
+    public PersonDTO findById(Integer id) {
         Person person = personRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Pessoa não encontrada com o id: " + id));
         return modelMapper.map(person, PersonDTO.class);
     }
 
-    public List<PersonDTO> findPersonsByCompanyId(Long companyId) {
+    public List<PersonDTO> findPersonsByCompanyId(Integer companyId) {
         return companyPartnerRepository.findByCompanyId(companyId)
                 .stream()
                 .map(companyPartner -> modelMapper.map(companyPartner.getPerson(), PersonDTO.class))

--- a/src/main/java/com/management/project/controller/ProjectController.java
+++ b/src/main/java/com/management/project/controller/ProjectController.java
@@ -3,13 +3,13 @@ package com.management.project.controller;
 import com.management.project.dto.ProjectCreateRequest;
 import com.management.project.dto.ProjectResponse;
 import com.management.project.service.ProjectService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 
@@ -38,17 +38,17 @@ public class ProjectController {
 
     @GetMapping("/projects/{id}")
     @Operation(summary = "Finds a project by ID")
-    public ResponseEntity<ProjectResponse> findById(@PathVariable Long id) {
+    public ResponseEntity<ProjectResponse> findById(@PathVariable Integer id) {
         return ResponseEntity.ok(projectService.findById(id));
     }
 
     @GetMapping("/companies/{companyId}/projects")
-    public ResponseEntity<List<ProjectResponse>> findByCompanyId(@PathVariable Long companyId) {
+    public ResponseEntity<List<ProjectResponse>> findByCompanyId(@PathVariable Integer companyId) {
         return ResponseEntity.ok(projectService.findByCompanyId(companyId));
     }
 
     @GetMapping("/persons/{personId}/projects")
-    public ResponseEntity<List<ProjectResponse>> findByPersonId(@PathVariable Long personId) {
+    public ResponseEntity<List<ProjectResponse>> findByPersonId(@PathVariable Integer personId) {
         return ResponseEntity.ok(projectService.findByPersonId(personId));
     }
 }

--- a/src/main/java/com/management/project/dto/ProjectCreateRequest.java
+++ b/src/main/java/com/management/project/dto/ProjectCreateRequest.java
@@ -19,10 +19,10 @@ public class ProjectCreateRequest {
     private LocalDate endDate;
 
     // Empresa (CNPJ)
-    private Long companyId;
+    private Integer companyId;
 
     // Pessoa física (CPF)
-    private Long ownerPersonId;
+    private Integer ownerPersonId;
 
-    private Long addressId;
+    private Integer addressId;
 }

--- a/src/main/java/com/management/project/dto/ProjectMapper.java
+++ b/src/main/java/com/management/project/dto/ProjectMapper.java
@@ -24,8 +24,8 @@ public class ProjectMapper {
         if (project.getOwnerPerson() != null) {
             response.setOwnerPersonId(project.getOwnerPerson().getId());
         }
-        if (project.getAddress() != null) {
-            response.setAddressId(project.getAddress().getId());
+        if (project.getAddresses() != null && !project.getAddresses().isEmpty()) {
+            response.setAddressId(project.getAddresses().get(0).getId());
         }
         return response;
     }

--- a/src/main/java/com/management/project/dto/ProjectResponse.java
+++ b/src/main/java/com/management/project/dto/ProjectResponse.java
@@ -6,14 +6,14 @@ import java.time.LocalDateTime;
 
 @Data
 public class ProjectResponse {
-    private Long id;
+    private Integer id;
     private String name;
     private String description;
     private LocalDate startDate;
     private LocalDate endDate;
-    private Long companyId;
-    private Long ownerPersonId;
-    private Long addressId;
+    private Integer companyId;
+    private Integer ownerPersonId;
+    private Integer addressId;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/management/project/model/Project.java
+++ b/src/main/java/com/management/project/model/Project.java
@@ -6,13 +6,14 @@ import com.management.person.model.Person;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(name = "project", schema = "management")
 public class Project {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Integer id;
 
     private String name;
     private String description;
@@ -31,9 +32,9 @@ public class Project {
     @JoinColumn(name = "fk_owner_person", nullable = true)
     private Person ownerPerson;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "fk_address")
-    private Address address;
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "fk_project")
+    private List<Address> addresses;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -54,11 +55,11 @@ public class Project {
 
     // Getters and Setters
 
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 
@@ -110,12 +111,12 @@ public class Project {
         this.ownerPerson = ownerPerson;
     }
 
-    public Address getAddress() {
-        return address;
+    public List<Address> getAddresses() {
+        return addresses;
     }
 
-    public void setAddress(Address address) {
-        this.address = address;
+    public void setAddresses(List<Address> addresses) {
+        this.addresses = addresses;
     }
 
     public LocalDateTime getCreatedAt() {

--- a/src/main/java/com/management/project/model/ProjectMember.java
+++ b/src/main/java/com/management/project/model/ProjectMember.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public class ProjectMember {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fk_project", nullable = false)
@@ -40,11 +40,11 @@ public class ProjectMember {
 
     // Getters and Setters
 
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/management/project/repository/ProjectMemberRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
-    List<ProjectMember> findByPersonId(Long personId);
+public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Integer> {
+    List<ProjectMember> findByPersonId(Integer personId);
 }

--- a/src/main/java/com/management/project/repository/ProjectRepository.java
+++ b/src/main/java/com/management/project/repository/ProjectRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProjectRepository extends JpaRepository<Project, Long> {
-    List<Project> findByCompanyId(Long companyId);
-    List<Project> findByOwnerPersonId(Long personId);
+public interface ProjectRepository extends JpaRepository<Project, Integer> {
+    List<Project> findByCompanyId(Integer companyId);
+    List<Project> findByOwnerPersonId(Integer personId);
 }

--- a/src/main/java/com/management/project/service/ProjectService.java
+++ b/src/main/java/com/management/project/service/ProjectService.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -80,7 +81,7 @@ public class ProjectService {
         if (request.getAddressId() != null) {
             Address address = addressRepository.findById(request.getAddressId())
                 .orElseThrow(() -> new BusinessException("Endereço não encontrado"));
-            project.setAddress(address);
+            project.setAddresses(Collections.singletonList(address));
         }
 
         Project saved = projectRepository.save(project);
@@ -103,14 +104,14 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public ProjectResponse findById(Long id) {
+    public ProjectResponse findById(Integer id) {
         Project project = projectRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + id));
         return projectMapper.toResponse(project);
     }
 
     @Transactional(readOnly = true)
-    public List<ProjectResponse> findByCompanyId(Long companyId) {
+    public List<ProjectResponse> findByCompanyId(Integer companyId) {
         if (!companyRepository.existsById(companyId)) {
             throw new ResourceNotFoundException("Company not found with id: " + companyId);
         }
@@ -118,7 +119,7 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProjectResponse> findByPersonId(Long personId) {
+    public List<ProjectResponse> findByPersonId(Integer personId) {
         if (!personRepository.existsById(personId)) {
             throw new ResourceNotFoundException("Person not found with id: " + personId);
         }

--- a/src/main/java/com/management/projectoccurrence/controller/ProjectOccurrenceController.java
+++ b/src/main/java/com/management/projectoccurrence/controller/ProjectOccurrenceController.java
@@ -4,12 +4,12 @@ import com.management.projectoccurrence.dto.ProjectOccurrenceCreateRequest;
 import com.management.projectoccurrence.dto.ProjectOccurrenceResponse;
 import com.management.projectoccurrence.dto.ProjectOccurrenceUpdateRequest;
 import com.management.projectoccurrence.service.ProjectOccurrenceService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 
@@ -32,25 +32,25 @@ public class ProjectOccurrenceController {
 
     @GetMapping("/occurrences/{id}")
     @Operation(summary = "Finds an occurrence by ID")
-    public ResponseEntity<ProjectOccurrenceResponse> getById(@PathVariable Long id) {
+    public ResponseEntity<ProjectOccurrenceResponse> getById(@PathVariable Integer id) {
         return ResponseEntity.ok(projectOccurrenceService.findById(id));
     }
 
     @GetMapping("/projects/{projectId}/occurrences")
     @Operation(summary = "Finds all occurrences for a project")
-    public ResponseEntity<List<ProjectOccurrenceResponse>> listByProject(@PathVariable Long projectId) {
+    public ResponseEntity<List<ProjectOccurrenceResponse>> listByProject(@PathVariable Integer projectId) {
         return ResponseEntity.ok(projectOccurrenceService.listByProject(projectId));
     }
 
     @PutMapping("/occurrences/{id}")
     @Operation(summary = "Updates an occurrence")
-    public ResponseEntity<ProjectOccurrenceResponse> update(@PathVariable Long id, @Valid @RequestBody ProjectOccurrenceUpdateRequest request) {
+    public ResponseEntity<ProjectOccurrenceResponse> update(@PathVariable Integer id, @Valid @RequestBody ProjectOccurrenceUpdateRequest request) {
         return ResponseEntity.ok(projectOccurrenceService.update(id, request));
     }
 
     @DeleteMapping("/occurrences/{id}")
     @Operation(summary = "Deletes an occurrence")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
+    public ResponseEntity<Void> delete(@PathVariable Integer id) {
         projectOccurrenceService.delete(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/management/projectoccurrence/dto/ProjectOccurrenceCreateRequest.java
+++ b/src/main/java/com/management/projectoccurrence/dto/ProjectOccurrenceCreateRequest.java
@@ -10,10 +10,10 @@ import java.time.LocalDate;
 public class ProjectOccurrenceCreateRequest {
 
     @NotNull
-    private Long projectId;
+    private Integer projectId;
 
     @NotNull
-    private Long personId;
+    private Integer personId;
 
     @NotNull
     private LocalDate occurrenceDate;

--- a/src/main/java/com/management/projectoccurrence/dto/ProjectOccurrenceResponse.java
+++ b/src/main/java/com/management/projectoccurrence/dto/ProjectOccurrenceResponse.java
@@ -8,9 +8,9 @@ import java.time.LocalDateTime;
 @Data
 public class ProjectOccurrenceResponse {
 
-    private Long id;
-    private Long projectId;
-    private Long personId;
+    private Integer id;
+    private Integer projectId;
+    private Integer personId;
     private LocalDate occurrenceDate;
     private String description;
     private LocalDateTime createdAt;

--- a/src/main/java/com/management/projectoccurrence/model/ProjectOccurrence.java
+++ b/src/main/java/com/management/projectoccurrence/model/ProjectOccurrence.java
@@ -12,7 +12,7 @@ public class ProjectOccurrence {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fk_project", nullable = false)
@@ -46,11 +46,11 @@ public class ProjectOccurrence {
     }
 
     // Getters and Setters
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/projectoccurrence/repository/ProjectOccurrenceRepository.java
+++ b/src/main/java/com/management/projectoccurrence/repository/ProjectOccurrenceRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProjectOccurrenceRepository extends JpaRepository<ProjectOccurrence, Long> {
+public interface ProjectOccurrenceRepository extends JpaRepository<ProjectOccurrence, Integer> {
 
-    List<ProjectOccurrence> findByProjectId(Long projectId);
+    List<ProjectOccurrence> findByProjectId(Integer projectId);
 }

--- a/src/main/java/com/management/projectoccurrence/service/ProjectOccurrenceService.java
+++ b/src/main/java/com/management/projectoccurrence/service/ProjectOccurrenceService.java
@@ -50,7 +50,7 @@ public class ProjectOccurrenceService {
     }
 
     @Transactional
-    public ProjectOccurrenceResponse update(Long id, ProjectOccurrenceUpdateRequest request) {
+    public ProjectOccurrenceResponse update(Integer id, ProjectOccurrenceUpdateRequest request) {
         ProjectOccurrence occurrence = projectOccurrenceRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Occurrence not found with id: " + id));
 
@@ -65,7 +65,7 @@ public class ProjectOccurrenceService {
     }
 
     @Transactional
-    public void delete(Long id) {
+    public void delete(Integer id) {
         if (!projectOccurrenceRepository.existsById(id)) {
             throw new ResourceNotFoundException("Occurrence not found with id: " + id);
         }
@@ -73,7 +73,7 @@ public class ProjectOccurrenceService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProjectOccurrenceResponse> listByProject(Long projectId) {
+    public List<ProjectOccurrenceResponse> listByProject(Integer projectId) {
         if (!projectRepository.existsById(projectId)) {
             throw new ResourceNotFoundException("Project not found with id: " + projectId);
         }
@@ -82,7 +82,7 @@ public class ProjectOccurrenceService {
                 .collect(Collectors.toList());
     }
      @Transactional(readOnly = true)
-    public ProjectOccurrenceResponse findById(Long id) {
+    public ProjectOccurrenceResponse findById(Integer id) {
         ProjectOccurrence occurrence = projectOccurrenceRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Occurrence not found with id: " + id));
         return projectOccurrenceMapper.toResponse(occurrence);

--- a/src/main/java/com/management/resource/controller/ProjectResourceController.java
+++ b/src/main/java/com/management/resource/controller/ProjectResourceController.java
@@ -4,13 +4,13 @@ import com.management.resource.dto.ProjectResourceCreateRequest;
 import com.management.resource.dto.ProjectResourceUpdateRequest;
 import com.management.resource.dto.ProjectResourceResponse;
 import com.management.resource.service.ProjectResourceService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 
@@ -30,25 +30,25 @@ public class ProjectResourceController {
 
     @GetMapping("/resources/{id}")
     @Operation(summary = "Finds a resource by ID")
-    public ResponseEntity<ProjectResourceResponse> getById(@PathVariable Long id) {
+    public ResponseEntity<ProjectResourceResponse> getById(@PathVariable Integer id) {
         return ResponseEntity.ok(resourceService.findById(id));
     }
 
     @GetMapping("/projects/{projectId}/resources")
     @Operation(summary = "Finds all resources for a project")
-    public ResponseEntity<List<ProjectResourceResponse>> getByProject(@PathVariable Long projectId) {
+    public ResponseEntity<List<ProjectResourceResponse>> getByProject(@PathVariable Integer projectId) {
         return ResponseEntity.ok(resourceService.listByProject(projectId));
     }
 
     @PutMapping("/resources/{id}")
     @Operation(summary = "Updates a resource")
-    public ResponseEntity<ProjectResourceResponse> update(@PathVariable Long id, @Valid @RequestBody ProjectResourceUpdateRequest request) {
+    public ResponseEntity<ProjectResourceResponse> update(@PathVariable Integer id, @Valid @RequestBody ProjectResourceUpdateRequest request) {
         return ResponseEntity.ok(resourceService.update(id, request));
     }
 
     @DeleteMapping("/resources/{id}")
     @Operation(summary = "Deletes a resource")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
+    public ResponseEntity<Void> delete(@PathVariable Integer id) {
         resourceService.delete(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/management/resource/dto/ProjectResourceCreateRequest.java
+++ b/src/main/java/com/management/resource/dto/ProjectResourceCreateRequest.java
@@ -10,7 +10,7 @@ import java.math.BigDecimal;
 public class ProjectResourceCreateRequest {
 
     @NotNull(message = "O ID do projeto é obrigatório")
-    private Long projectId;
+    private Integer projectId;
 
     @NotBlank(message = "O nome do recurso é obrigatório")
     private String name;

--- a/src/main/java/com/management/resource/dto/ProjectResourceResponse.java
+++ b/src/main/java/com/management/resource/dto/ProjectResourceResponse.java
@@ -6,8 +6,8 @@ import java.time.LocalDateTime;
 
 @Data
 public class ProjectResourceResponse {
-    private Long id;
-    private Long projectId;
+    private Integer id;
+    private Integer projectId;
     private String name;
     private String unit;
     private BigDecimal quantity;

--- a/src/main/java/com/management/resource/model/ProjectResource.java
+++ b/src/main/java/com/management/resource/model/ProjectResource.java
@@ -13,7 +13,7 @@ public class ProjectResource {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fk_project", nullable = false)

--- a/src/main/java/com/management/resource/repository/ProjectResourceRepository.java
+++ b/src/main/java/com/management/resource/repository/ProjectResourceRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProjectResourceRepository extends JpaRepository<ProjectResource, Long> {
-    List<ProjectResource> findByProjectId(Long projectId);
+public interface ProjectResourceRepository extends JpaRepository<ProjectResource, Integer> {
+    List<ProjectResource> findByProjectId(Integer projectId);
 }

--- a/src/main/java/com/management/resource/service/ProjectResourceService.java
+++ b/src/main/java/com/management/resource/service/ProjectResourceService.java
@@ -41,7 +41,7 @@ public class ProjectResourceService {
     }
 
     @Transactional
-    public ProjectResourceResponse update(Long id, @Valid ProjectResourceUpdateRequest request) {
+    public ProjectResourceResponse update(Integer id, @Valid ProjectResourceUpdateRequest request) {
         ProjectResource resource = resourceRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Recurso não encontrado com o id: " + id));
 
@@ -60,20 +60,20 @@ public class ProjectResourceService {
     }
 
     @Transactional
-    public void delete(Long id) {
+    public void delete(Integer id) {
         if (!resourceRepository.existsById(id)) {
             throw new ResourceNotFoundException("Recurso não encontrado com o id: " + id);
         }
         resourceRepository.deleteById(id);
     }
 
-    public ProjectResourceResponse findById(Long id) {
+    public ProjectResourceResponse findById(Integer id) {
         ProjectResource resource = resourceRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Recurso não encontrado com o id: " + id));
         return resourceMapper.toResponse(resource);
     }
 
-    public List<ProjectResourceResponse> listByProject(Long projectId) {
+    public List<ProjectResourceResponse> listByProject(Integer projectId) {
         if (!projectRepository.existsById(projectId)) {
             throw new ResourceNotFoundException("Projeto não encontrado com o id: " + projectId);
         }

--- a/src/main/java/com/management/role/model/Role.java
+++ b/src/main/java/com/management/role/model/Role.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 public class Role {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Integer id;
 
     @Column(unique = true, nullable = false)
     private String name;
@@ -33,11 +33,11 @@ public class Role {
     }
 
     // Getters and Setters
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/src/main/java/com/management/state/dto/StateResponseDTO.java
+++ b/src/main/java/com/management/state/dto/StateResponseDTO.java
@@ -4,7 +4,7 @@ import lombok.Data;
 
 @Data
 public class StateResponseDTO {
-    private Long id;
+    private Integer id;
     private String name;
     private String uf;
 }

--- a/src/main/java/com/management/task/controller/ProjectTaskController.java
+++ b/src/main/java/com/management/task/controller/ProjectTaskController.java
@@ -4,13 +4,13 @@ import com.management.task.dto.ProjectTaskCreateRequest;
 import com.management.task.dto.ProjectTaskUpdateRequest;
 import com.management.task.dto.ProjectTaskResponse;
 import com.management.task.service.ProjectTaskService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 
@@ -30,28 +30,28 @@ public class ProjectTaskController {
 
     @GetMapping("/tasks/{id}")
     @Operation(summary = "Finds a task by ID")
-    public ResponseEntity<ProjectTaskResponse> getTaskById(@PathVariable Long id) {
+    public ResponseEntity<ProjectTaskResponse> getTaskById(@PathVariable Integer id) {
         ProjectTaskResponse task = taskService.findTaskById(id);
         return ResponseEntity.ok(task);
     }
 
     @GetMapping("/projects/{projectId}/tasks")
     @Operation(summary = "Finds all tasks for a project")
-    public ResponseEntity<List<ProjectTaskResponse>> getTasksByProject(@PathVariable Long projectId) {
+    public ResponseEntity<List<ProjectTaskResponse>> getTasksByProject(@PathVariable Integer projectId) {
         List<ProjectTaskResponse> tasks = taskService.listByProject(projectId);
         return ResponseEntity.ok(tasks);
     }
 
     @PutMapping("/tasks/{id}")
     @Operation(summary = "Updates a task")
-    public ResponseEntity<ProjectTaskResponse> updateTask(@PathVariable Long id, @Valid @RequestBody ProjectTaskUpdateRequest request) {
+    public ResponseEntity<ProjectTaskResponse> updateTask(@PathVariable Integer id, @Valid @RequestBody ProjectTaskUpdateRequest request) {
         ProjectTaskResponse updatedTask = taskService.updateTask(id, request);
         return ResponseEntity.ok(updatedTask);
     }
 
     @DeleteMapping("/tasks/{id}")
     @Operation(summary = "Deletes a task")
-    public ResponseEntity<Void> deleteTask(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteTask(@PathVariable Integer id) {
         taskService.deleteTask(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/management/task/dto/ProjectTaskCreateRequest.java
+++ b/src/main/java/com/management/task/dto/ProjectTaskCreateRequest.java
@@ -16,9 +16,9 @@ public class ProjectTaskCreateRequest {
     private LocalDate dueDate;
 
     @NotNull(message = "O ID do projeto é obrigatório")
-    private Long projectId;
+    private Integer projectId;
 
-    private Long responsibleId;
+    private Integer responsibleId;
 
-    private Long parentId;
+    private Integer parentId;
 }

--- a/src/main/java/com/management/task/dto/ProjectTaskResponse.java
+++ b/src/main/java/com/management/task/dto/ProjectTaskResponse.java
@@ -6,14 +6,14 @@ import java.time.LocalDateTime;
 
 @Data
 public class ProjectTaskResponse {
-    private Long id;
+    private Integer id;
     private String title;
     private String description;
     private String status;
     private LocalDate dueDate;
-    private Long projectId;
-    private Long responsibleId;
-    private Long parentId;
+    private Integer projectId;
+    private Integer responsibleId;
+    private Integer parentId;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/management/task/dto/ProjectTaskUpdateRequest.java
+++ b/src/main/java/com/management/task/dto/ProjectTaskUpdateRequest.java
@@ -9,5 +9,5 @@ public class ProjectTaskUpdateRequest {
     private String description;
     private String status;
     private LocalDate dueDate;
-    private Long responsibleId;
+    private Integer responsibleId;
 }

--- a/src/main/java/com/management/task/model/ProjectTask.java
+++ b/src/main/java/com/management/task/model/ProjectTask.java
@@ -14,7 +14,7 @@ public class ProjectTask {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Integer id;
 
     @Column(nullable = false)
     private String title;

--- a/src/main/java/com/management/task/repository/ProjectTaskRepository.java
+++ b/src/main/java/com/management/task/repository/ProjectTaskRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProjectTaskRepository extends JpaRepository<ProjectTask, Long> {
-    List<ProjectTask> findByProjectId(Long projectId);
+public interface ProjectTaskRepository extends JpaRepository<ProjectTask, Integer> {
+    List<ProjectTask> findByProjectId(Integer projectId);
 }

--- a/src/main/java/com/management/task/service/ProjectTaskService.java
+++ b/src/main/java/com/management/task/service/ProjectTaskService.java
@@ -56,7 +56,7 @@ public class ProjectTaskService {
     }
 
     @Transactional
-    public ProjectTaskResponse updateTask(Long id, @Valid ProjectTaskUpdateRequest request) {
+    public ProjectTaskResponse updateTask(Integer id, @Valid ProjectTaskUpdateRequest request) {
         ProjectTask task = taskRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Tarefa não encontrada com o id: " + id));
 
@@ -82,7 +82,7 @@ public class ProjectTaskService {
         return taskMapper.toResponse(updatedTask);
     }
 
-    public List<ProjectTaskResponse> listByProject(Long projectId) {
+    public List<ProjectTaskResponse> listByProject(Integer projectId) {
         if (!projectRepository.existsById(projectId)) {
             throw new ResourceNotFoundException("Projeto não encontrado com o id: " + projectId);
         }
@@ -91,14 +91,14 @@ public class ProjectTaskService {
                 .collect(Collectors.toList());
     }
 
-    public ProjectTaskResponse findTaskById(Long id) {
+    public ProjectTaskResponse findTaskById(Integer id) {
         ProjectTask task = taskRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Tarefa não encontrada com o id: " + id));
         return taskMapper.toResponse(task);
     }
 
     @Transactional
-    public void deleteTask(Long id) {
+    public void deleteTask(Integer id) {
         if (!taskRepository.existsById(id)) {
             throw new ResourceNotFoundException("Tarefa não encontrada com o id: " + id);
         }

--- a/src/test/java/com/management/address/controller/ProjectAddressControllerTest.java
+++ b/src/test/java/com/management/address/controller/ProjectAddressControllerTest.java
@@ -18,8 +18,10 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.Collections;
+
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -50,7 +52,7 @@ public class ProjectAddressControllerTest {
         requestDTO.setNumber("123");
         requestDTO.setNeighborhood("Test Neighborhood");
         requestDTO.setZipCode("12345-678");
-        requestDTO.setCityId(1L);
+        requestDTO.setCityId(1);
 
         responseDTO = new ProjectAddressResponseDTO();
         responseDTO.setStreet("Test Street");
@@ -58,7 +60,7 @@ public class ProjectAddressControllerTest {
 
     @Test
     void testCreateProjectAddress() throws Exception {
-        when(projectAddressService.createProjectAddress(anyLong(), any(ProjectAddressRequestDTO.class))).thenReturn(responseDTO);
+        when(projectAddressService.createProjectAddress(anyInt(), any(ProjectAddressRequestDTO.class))).thenReturn(responseDTO);
 
         mockMvc.perform(post("/api/projects/1/addresses")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -68,19 +70,28 @@ public class ProjectAddressControllerTest {
     }
 
     @Test
-    void testGetProjectAddress() throws Exception {
-        when(projectAddressService.getProjectAddress(anyLong())).thenReturn(responseDTO);
+    void testGetAllProjectAddresses() throws Exception {
+        when(projectAddressService.getAllProjectAddresses(anyInt())).thenReturn(Collections.singletonList(responseDTO));
 
         mockMvc.perform(get("/api/projects/1/addresses"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].street").value("Test Street"));
+    }
+
+    @Test
+    void testGetProjectAddressById() throws Exception {
+        when(projectAddressService.getProjectAddressById(anyInt(), anyInt())).thenReturn(responseDTO);
+
+        mockMvc.perform(get("/api/projects/1/addresses/1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.street").value("Test Street"));
     }
 
     @Test
     void testUpdateProjectAddress() throws Exception {
-        when(projectAddressService.updateProjectAddress(anyLong(), any(ProjectAddressRequestDTO.class))).thenReturn(responseDTO);
+        when(projectAddressService.updateProjectAddress(anyInt(), anyInt(), any(ProjectAddressRequestDTO.class))).thenReturn(responseDTO);
 
-        mockMvc.perform(put("/api/projects/1/addresses")
+        mockMvc.perform(put("/api/projects/1/addresses/1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDTO)))
                 .andExpect(status().isOk())
@@ -89,9 +100,9 @@ public class ProjectAddressControllerTest {
 
     @Test
     void testDeleteProjectAddress() throws Exception {
-        doNothing().when(projectAddressService).deleteProjectAddress(anyLong());
+        doNothing().when(projectAddressService).deleteProjectAddress(anyInt(), anyInt());
 
-        mockMvc.perform(delete("/api/projects/1/addresses"))
+        mockMvc.perform(delete("/api/projects/1/addresses/1"))
                 .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/management/address/service/ProjectAddressServiceTest.java
+++ b/src/test/java/com/management/address/service/ProjectAddressServiceTest.java
@@ -18,6 +18,9 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -50,30 +53,30 @@ public class ProjectAddressServiceTest {
     @BeforeEach
     void setUp() {
         city = new City();
-        city.setId(1L);
+        city.setId(1);
         city.setName("Test City");
 
         address = new Address();
-        address.setId(1L);
+        address.setId(1);
         address.setStreet("Test Street");
         address.setCity(city);
 
         project = new Project();
-        project.setId(1L);
-        project.setAddress(address);
+        project.setId(1);
+        project.setAddresses(new ArrayList<>(List.of(address)));
 
         requestDTO = new ProjectAddressRequestDTO();
-        requestDTO.setCityId(1L);
+        requestDTO.setCityId(1);
         requestDTO.setStreet("Test Street");
     }
 
     @Test
     void testCreateProjectAddress() {
-        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
-        when(cityRepository.findById(1L)).thenReturn(Optional.of(city));
+        when(projectRepository.findById(1)).thenReturn(Optional.of(project));
+        when(cityRepository.findById(1)).thenReturn(Optional.of(city));
         when(projectRepository.save(any(Project.class))).thenReturn(project);
 
-        ProjectAddressResponseDTO responseDTO = projectAddressService.createProjectAddress(1L, requestDTO);
+        ProjectAddressResponseDTO responseDTO = projectAddressService.createProjectAddress(1, requestDTO);
 
         assertNotNull(responseDTO);
         assertEquals("Test Street", responseDTO.getStreet());
@@ -81,31 +84,44 @@ public class ProjectAddressServiceTest {
     }
 
     @Test
-    void testGetProjectAddress() {
-        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+    void testGetAllProjectAddresses() {
+        when(projectRepository.findById(1)).thenReturn(Optional.of(project));
 
-        ProjectAddressResponseDTO responseDTO = projectAddressService.getProjectAddress(1L);
+        List<ProjectAddressResponseDTO> responseDTO = projectAddressService.getAllProjectAddresses(1);
+
+        assertNotNull(responseDTO);
+        assertFalse(responseDTO.isEmpty());
+        assertEquals("Test Street", responseDTO.get(0).getStreet());
+    }
+
+    @Test
+    void testGetProjectAddressById() {
+        when(projectRepository.findById(1)).thenReturn(Optional.of(project));
+
+        ProjectAddressResponseDTO responseDTO = projectAddressService.getProjectAddressById(1, 1);
 
         assertNotNull(responseDTO);
         assertEquals("Test Street", responseDTO.getStreet());
     }
 
     @Test
-    void testGetProjectAddress_NotFound() {
-        when(projectRepository.findById(1L)).thenReturn(Optional.of(new Project()));
+    void testGetProjectAddressById_NotFound() {
+        Project project = new Project();
+        project.setAddresses(Collections.emptyList());
+        when(projectRepository.findById(1)).thenReturn(Optional.of(project));
 
         assertThrows(ResourceNotFoundException.class, () -> {
-            projectAddressService.getProjectAddress(1L);
+            projectAddressService.getProjectAddressById(1, 1);
         });
     }
 
     @Test
     void testUpdateProjectAddress() {
-        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
-        when(cityRepository.findById(1L)).thenReturn(Optional.of(city));
+        when(projectRepository.findById(1)).thenReturn(Optional.of(project));
+        when(cityRepository.findById(1)).thenReturn(Optional.of(city));
         when(addressRepository.save(any(Address.class))).thenReturn(address);
 
-        ProjectAddressResponseDTO responseDTO = projectAddressService.updateProjectAddress(1L, requestDTO);
+        ProjectAddressResponseDTO responseDTO = projectAddressService.updateProjectAddress(1, 1, requestDTO);
 
         assertNotNull(responseDTO);
         assertEquals("Test Street", responseDTO.getStreet());
@@ -114,12 +130,12 @@ public class ProjectAddressServiceTest {
 
     @Test
     void testDeleteProjectAddress() {
-        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+        when(projectRepository.findById(1)).thenReturn(Optional.of(project));
         when(projectRepository.save(any(Project.class))).thenReturn(project);
 
-        projectAddressService.deleteProjectAddress(1L);
+        projectAddressService.deleteProjectAddress(1, 1);
 
         verify(projectRepository, times(1)).save(project);
-        assertNull(project.getAddress());
+        assertTrue(project.getAddresses().isEmpty());
     }
 }

--- a/src/test/java/com/management/person/service/PersonServiceTest.java
+++ b/src/test/java/com/management/person/service/PersonServiceTest.java
@@ -54,7 +54,7 @@ class PersonServiceTest {
         createDTO.setCnpj("12345678901234");
 
         Person person = new Person();
-        person.setId(1L);
+        person.setId(1);
 
         CnpjResponseDTO cnpjResponse = new CnpjResponseDTO();
         cnpjResponse.setRazaoSocial("Test Company");
@@ -80,7 +80,7 @@ class PersonServiceTest {
         createDTO.setFullName("Test User");
 
         Person person = new Person();
-        person.setId(1L);
+        person.setId(1);
 
         when(modelMapper.map(any(PersonCreateDTO.class), eq(Person.class))).thenReturn(person);
         when(personRepository.save(any(Person.class))).thenReturn(person);

--- a/src/test/java/com/management/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/management/project/service/ProjectServiceTest.java
@@ -70,8 +70,8 @@ class ProjectServiceTest {
 
     @Test
     void create_shouldThrowBusinessException_whenBothCompanyIdAndOwnerPersonIdAreProvided() {
-        projectCreateRequest.setCompanyId(1L);
-        projectCreateRequest.setOwnerPersonId(1L);
+        projectCreateRequest.setCompanyId(1);
+        projectCreateRequest.setOwnerPersonId(1);
 
         assertThrows(BusinessException.class, () -> projectService.create(projectCreateRequest));
     }
@@ -83,22 +83,22 @@ class ProjectServiceTest {
 
     @Test
     void create_shouldCreateCorporateProject_whenCompanyIdIsProvided() {
-        projectCreateRequest.setCompanyId(1L);
+        projectCreateRequest.setCompanyId(1);
 
         Company company = new Company();
-        company.setId(1L);
-        when(companyRepository.findById(1L)).thenReturn(Optional.of(company));
+        company.setId(1);
+        when(companyRepository.findById(1)).thenReturn(Optional.of(company));
 
         Project project = new Project();
-        project.setId(1L);
+        project.setId(1);
         project.setName(projectCreateRequest.getName());
         project.setCompany(company);
         when(projectRepository.save(any(Project.class))).thenReturn(project);
 
         ProjectResponse projectResponse = new ProjectResponse();
-        projectResponse.setId(1L);
+        projectResponse.setId(1);
         projectResponse.setName("New Project");
-        projectResponse.setCompanyId(1L);
+        projectResponse.setCompanyId(1);
         when(projectMapper.toResponse(any(Project.class))).thenReturn(projectResponse);
 
         ProjectResponse response = projectService.create(projectCreateRequest);
@@ -113,22 +113,22 @@ class ProjectServiceTest {
 
     @Test
     void create_shouldCreatePersonalProjectAndProjectMember_whenOwnerPersonIdIsProvided() {
-        projectCreateRequest.setOwnerPersonId(1L);
+        projectCreateRequest.setOwnerPersonId(1);
 
         Person person = new Person();
-        person.setId(1L);
-        when(personRepository.findById(1L)).thenReturn(Optional.of(person));
+        person.setId(1);
+        when(personRepository.findById(1)).thenReturn(Optional.of(person));
 
         Project project = new Project();
-        project.setId(1L);
+        project.setId(1);
         project.setName(projectCreateRequest.getName());
         project.setOwnerPerson(person);
         when(projectRepository.save(any(Project.class))).thenReturn(project);
 
         ProjectResponse projectResponse = new ProjectResponse();
-        projectResponse.setId(1L);
+        projectResponse.setId(1);
         projectResponse.setName("New Project");
-        projectResponse.setOwnerPersonId(1L);
+        projectResponse.setOwnerPersonId(1);
         when(projectMapper.toResponse(any(Project.class))).thenReturn(projectResponse);
 
         ProjectResponse response = projectService.create(projectCreateRequest);
@@ -143,26 +143,26 @@ class ProjectServiceTest {
 
     @Test
     void create_shouldSetAddress_whenAddressIdIsProvided() {
-        projectCreateRequest.setCompanyId(1L);
-        projectCreateRequest.setAddressId(1L);
+        projectCreateRequest.setCompanyId(1);
+        projectCreateRequest.setAddressId(1);
 
         Company company = new Company();
-        company.setId(1L);
-        when(companyRepository.findById(1L)).thenReturn(Optional.of(company));
+        company.setId(1);
+        when(companyRepository.findById(1)).thenReturn(Optional.of(company));
 
         Address address = new Address();
-        address.setId(1L);
-        when(addressRepository.findById(1L)).thenReturn(Optional.of(address));
+        address.setId(1);
+        when(addressRepository.findById(1)).thenReturn(Optional.of(address));
 
         Project project = new Project();
-        project.setId(1L);
+        project.setId(1);
         project.setName(projectCreateRequest.getName());
         project.setCompany(company);
-        project.setAddress(address);
+        project.setAddresses(Collections.singletonList(address));
         when(projectRepository.save(any(Project.class))).thenReturn(project);
 
         ProjectResponse projectResponse = new ProjectResponse();
-        projectResponse.setAddressId(1L);
+        projectResponse.setAddressId(1);
         when(projectMapper.toResponse(any(Project.class))).thenReturn(projectResponse);
 
         ProjectResponse response = projectService.create(projectCreateRequest);
@@ -185,14 +185,14 @@ class ProjectServiceTest {
     @Test
     void findById_shouldReturnProject() {
         Project project = new Project();
-        project.setId(1L);
-        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+        project.setId(1);
+        when(projectRepository.findById(1)).thenReturn(Optional.of(project));
 
         ProjectResponse projectResponse = new ProjectResponse();
-        projectResponse.setId(1L);
+        projectResponse.setId(1);
         when(projectMapper.toResponse(any(Project.class))).thenReturn(projectResponse);
 
-        ProjectResponse response = projectService.findById(1L);
+        ProjectResponse response = projectService.findById(1);
 
         assertNotNull(response);
         assertEquals(1, response.getId());
@@ -200,11 +200,11 @@ class ProjectServiceTest {
 
     @Test
     void findByCompanyId_shouldReturnListOfProjects() {
-        when(companyRepository.existsById(1L)).thenReturn(true);
-        when(projectRepository.findByCompanyId(1L)).thenReturn(Collections.singletonList(new Project()));
+        when(companyRepository.existsById(1)).thenReturn(true);
+        when(projectRepository.findByCompanyId(1)).thenReturn(Collections.singletonList(new Project()));
         when(projectMapper.toResponse(any(List.class))).thenReturn(Collections.singletonList(new ProjectResponse()));
 
-        List<ProjectResponse> response = projectService.findByCompanyId(1L);
+        List<ProjectResponse> response = projectService.findByCompanyId(1);
 
         assertNotNull(response);
         assertEquals(1, response.size());
@@ -212,12 +212,12 @@ class ProjectServiceTest {
 
     @Test
     void findByPersonId_shouldReturnListOfProjects() {
-        when(personRepository.existsById(1L)).thenReturn(true);
-        when(projectRepository.findByOwnerPersonId(1L)).thenReturn(Collections.singletonList(new Project()));
-        when(projectMemberRepository.findByPersonId(1L)).thenReturn(Collections.emptyList());
+        when(personRepository.existsById(1)).thenReturn(true);
+        when(projectRepository.findByOwnerPersonId(1)).thenReturn(Collections.singletonList(new Project()));
+        when(projectMemberRepository.findByPersonId(1)).thenReturn(Collections.emptyList());
         when(projectMapper.toResponse(any(List.class))).thenReturn(Collections.singletonList(new ProjectResponse()));
 
-        List<ProjectResponse> response = projectService.findByPersonId(1L);
+        List<ProjectResponse> response = projectService.findByPersonId(1);
 
         assertNotNull(response);
         assertEquals(1, response.size());

--- a/src/test/java/com/management/projectoccurrence/service/ProjectOccurrenceServiceTest.java
+++ b/src/test/java/com/management/projectoccurrence/service/ProjectOccurrenceServiceTest.java
@@ -61,18 +61,18 @@ class ProjectOccurrenceServiceTest {
     @Test
     void testCreate() {
         ProjectOccurrenceCreateRequest request = new ProjectOccurrenceCreateRequest();
-        request.setProjectId(1L);
-        request.setPersonId(1L);
+        request.setProjectId(1);
+        request.setPersonId(1);
         request.setDescription("Test Description");
         request.setOccurrenceDate(LocalDate.now());
 
         Project project = new Project();
-        project.setId(1L);
+        project.setId(1);
         Person person = new Person();
-        person.setId(1L);
+        person.setId(1);
 
-        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
-        when(personRepository.findById(1L)).thenReturn(Optional.of(person));
+        when(projectRepository.findById(1)).thenReturn(Optional.of(project));
+        when(personRepository.findById(1)).thenReturn(Optional.of(person));
         when(projectOccurrenceRepository.save(any(ProjectOccurrence.class))).thenAnswer(i -> i.getArguments()[0]);
 
         ProjectOccurrenceResponse response = projectOccurrenceService.create(request);
@@ -88,21 +88,21 @@ class ProjectOccurrenceServiceTest {
         request.setDescription("Updated Description");
 
         Project project = new Project();
-        project.setId(1L);
+        project.setId(1);
         Person person = new Person();
-        person.setId(1L);
+        person.setId(1);
 
         ProjectOccurrence occurrence = new ProjectOccurrence();
-        occurrence.setId(1L);
+        occurrence.setId(1);
         occurrence.setDescription("Old Description");
         occurrence.setProject(project);
         occurrence.setPerson(person);
 
 
-        when(projectOccurrenceRepository.findById(1L)).thenReturn(Optional.of(occurrence));
+        when(projectOccurrenceRepository.findById(1)).thenReturn(Optional.of(occurrence));
         when(projectOccurrenceRepository.save(any(ProjectOccurrence.class))).thenAnswer(i -> i.getArguments()[0]);
 
-        ProjectOccurrenceResponse response = projectOccurrenceService.update(1L, request);
+        ProjectOccurrenceResponse response = projectOccurrenceService.update(1, request);
 
         assertNotNull(response);
         assertEquals("Updated Description", response.getDescription());
@@ -110,30 +110,30 @@ class ProjectOccurrenceServiceTest {
 
     @Test
     void testDelete() {
-        when(projectOccurrenceRepository.existsById(1L)).thenReturn(true);
-        doNothing().when(projectOccurrenceRepository).deleteById(1L);
+        when(projectOccurrenceRepository.existsById(1)).thenReturn(true);
+        doNothing().when(projectOccurrenceRepository).deleteById(1);
 
-        projectOccurrenceService.delete(1L);
+        projectOccurrenceService.delete(1);
 
-        verify(projectOccurrenceRepository, times(1)).deleteById(1L);
+        verify(projectOccurrenceRepository, times(1)).deleteById(1);
     }
 
     @Test
     void testListByProject() {
         Project project = new Project();
-        project.setId(1L);
+        project.setId(1);
         Person person = new Person();
-        person.setId(1L);
+        person.setId(1);
 
         ProjectOccurrence occurrence = new ProjectOccurrence();
-        occurrence.setId(1L);
+        occurrence.setId(1);
         occurrence.setProject(project);
         occurrence.setPerson(person);
 
-        when(projectRepository.existsById(1L)).thenReturn(true);
-        when(projectOccurrenceRepository.findByProjectId(1L)).thenReturn(Collections.singletonList(occurrence));
+        when(projectRepository.existsById(1)).thenReturn(true);
+        when(projectOccurrenceRepository.findByProjectId(1)).thenReturn(Collections.singletonList(occurrence));
 
-        List<ProjectOccurrenceResponse> response = projectOccurrenceService.listByProject(1L);
+        List<ProjectOccurrenceResponse> response = projectOccurrenceService.listByProject(1);
 
         assertNotNull(response);
         assertFalse(response.isEmpty());
@@ -143,18 +143,18 @@ class ProjectOccurrenceServiceTest {
     @Test
     void testFindById() {
         Project project = new Project();
-        project.setId(1L);
+        project.setId(1);
         Person person = new Person();
-        person.setId(1L);
+        person.setId(1);
 
         ProjectOccurrence occurrence = new ProjectOccurrence();
-        occurrence.setId(1L);
+        occurrence.setId(1);
         occurrence.setProject(project);
         occurrence.setPerson(person);
 
-        when(projectOccurrenceRepository.findById(1L)).thenReturn(Optional.of(occurrence));
+        when(projectOccurrenceRepository.findById(1)).thenReturn(Optional.of(occurrence));
 
-        ProjectOccurrenceResponse response = projectOccurrenceService.findById(1L);
+        ProjectOccurrenceResponse response = projectOccurrenceService.findById(1);
 
         assertNotNull(response);
         assertEquals(1, response.getId());
@@ -163,9 +163,9 @@ class ProjectOccurrenceServiceTest {
     @Test
     void testCreate_ProjectNotFound() {
         ProjectOccurrenceCreateRequest request = new ProjectOccurrenceCreateRequest();
-        request.setProjectId(1L);
+        request.setProjectId(1);
 
-        when(projectRepository.findById(1L)).thenReturn(Optional.empty());
+        when(projectRepository.findById(1)).thenReturn(Optional.empty());
 
         assertThrows(ResourceNotFoundException.class, () -> projectOccurrenceService.create(request));
     }

--- a/src/test/java/com/management/resource/service/ProjectResourceServiceTest.java
+++ b/src/test/java/com/management/resource/service/ProjectResourceServiceTest.java
@@ -37,13 +37,13 @@ class ProjectResourceServiceTest {
         // Arrange
         ProjectResourceCreateRequest request = new ProjectResourceCreateRequest();
         request.setName("New Resource");
-        request.setProjectId(1L);
+        request.setProjectId(1);
 
         Project project = new Project();
         ProjectResource resource = new ProjectResource();
         ProjectResourceResponse response = new ProjectResourceResponse();
 
-        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+        when(projectRepository.findById(1)).thenReturn(Optional.of(project));
         when(resourceRepository.save(any(ProjectResource.class))).thenReturn(resource);
         when(resourceMapper.toResponse(resource)).thenReturn(response);
 

--- a/src/test/java/com/management/task/service/ProjectTaskServiceTest.java
+++ b/src/test/java/com/management/task/service/ProjectTaskServiceTest.java
@@ -41,16 +41,16 @@ class ProjectTaskServiceTest {
         // Arrange
         ProjectTaskCreateRequest request = new ProjectTaskCreateRequest();
         request.setTitle("New Task");
-        request.setProjectId(1L);
-        request.setResponsibleId(1L);
+        request.setProjectId(1);
+        request.setResponsibleId(1);
 
         Project project = new Project();
         Person person = new Person();
         ProjectTask task = new ProjectTask();
         ProjectTaskResponse response = new ProjectTaskResponse();
 
-        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
-        when(personRepository.findById(1L)).thenReturn(Optional.of(person));
+        when(projectRepository.findById(1)).thenReturn(Optional.of(project));
+        when(personRepository.findById(1)).thenReturn(Optional.of(person));
         when(taskRepository.save(any(ProjectTask.class))).thenReturn(task);
         when(taskMapper.toResponse(task)).thenReturn(response);
 


### PR DESCRIPTION
This commit reverts all entity ID fields from `Long` back to `Integer` as requested. This change has been applied to all affected models, repositories, DTOs, services, controllers, and tests.

It also fixes the implementation of the `ProjectAddress` CRUD to support a one-to-many relationship, as pointed out in the code review.

Key changes:
- Reverted all entity IDs from `Long` to `Integer`.
- Updated all related tests to use `Integer` for IDs.
- Updated the `Project` entity to have a one-to-many relationship with the `Address` entity.
- Updated the `ProjectAddressService` and `ProjectAddressController` to handle multiple addresses for a project.