### PR TITLE
fix(jpa): correct project-address entity relationship

### DIFF
--- a/src/main/java/com/management/address/model/Address.java
+++ b/src/main/java/com/management/address/model/Address.java
@@ -1,6 +1,7 @@
 package com.management.address.model;
 
 import com.management.city.model.City;
+import com.management.project.model.Project;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
@@ -20,6 +21,10 @@ public class Address {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fk_city", nullable = false)
     private City city;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fk_project")
+    private Project project;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -84,6 +89,14 @@ public class Address {
 
     public void setCity(City city) {
         this.city = city;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public void setProject(Project project) {
+        this.project = project;
     }
 
     public LocalDateTime getCreatedAt() {

--- a/src/main/java/com/management/project/model/Project.java
+++ b/src/main/java/com/management/project/model/Project.java
@@ -32,8 +32,7 @@ public class Project {
     @JoinColumn(name = "fk_owner_person", nullable = true)
     private Person ownerPerson;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "fk_project")
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Address> addresses;
 
     @Column(name = "created_at", nullable = false, updatable = false)


### PR DESCRIPTION
Resolves a SchemaManagementException that occurred on application startup.

The exception was caused by an incorrect unidirectional @OneToMany mapping from Project to Address, which resulted in Hibernate expecting a 'fk_project' column in the 'address' table that did not exist in the entity definition.

This commit refactors the relationship to be a standard bidirectional @OneToMany/@ManyToOne mapping:
- The Project entity's @OneToMany annotation now uses 'mappedBy' to delegate ownership to the Address entity.
- The Address entity now has a corresponding @ManyToOne relationship back to the Project, with the appropriate @JoinColumn('fk_project').