### PR TITLE
feat: Synchronize JPA entities with the database schema

### DIFF
--- a/src/main/java/com/management/company/model/Company.java
+++ b/src/main/java/com/management/company/model/Company.java
@@ -4,6 +4,7 @@ import com.management.address.model.Address;
 import com.management.plantype.model.PlanType;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(name = "company", schema = "management")
@@ -34,6 +35,9 @@ public class Company {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fk_plan_type", nullable = false)
     private PlanType planType;
+
+    @OneToMany(mappedBy = "company")
+    private List<CompanyMember> companyMembers;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -132,5 +136,13 @@ public class Company {
 
     public void setUpdatedAt(LocalDateTime updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public List<CompanyMember> getCompanyMembers() {
+        return companyMembers;
+    }
+
+    public void setCompanyMembers(List<CompanyMember> companyMembers) {
+        this.companyMembers = companyMembers;
     }
 }

--- a/src/main/java/com/management/company/model/CompanyMember.java
+++ b/src/main/java/com/management/company/model/CompanyMember.java
@@ -1,0 +1,93 @@
+package com.management.company.model;
+
+import com.management.person.model.Person;
+import com.management.role.model.Role;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "company_member", schema = "management",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"fk_company", "fk_person"}))
+public class CompanyMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fk_company", nullable = false)
+    private Company company;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fk_person", nullable = false)
+    private Person person;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fk_role", nullable = false)
+    private Role role;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    // Getters and Setters
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Company getCompany() {
+        return company;
+    }
+
+    public void setCompany(Company company) {
+        this.company = company;
+    }
+
+    public Person getPerson() {
+        return person;
+    }
+
+    public void setPerson(Person person) {
+        this.person = person;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/management/person/model/Person.java
+++ b/src/main/java/com/management/person/model/Person.java
@@ -1,10 +1,11 @@
 package com.management.person.model;
 
 import com.management.address.model.Address;
-import com.management.role.model.Role;
+import com.management.company.model.CompanyMember;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(name = "person", schema = "management")
@@ -28,12 +29,11 @@ public class Person {
     private LocalDate birthDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "fk_role")
-    private Role role;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fk_address")
     private Address address;
+
+    @OneToMany(mappedBy = "person")
+    private List<CompanyMember> companyMembers;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -101,14 +101,6 @@ public class Person {
         this.birthDate = birthDate;
     }
 
-    public Role getRole() {
-        return role;
-    }
-
-    public void setRole(Role role) {
-        this.role = role;
-    }
-
     public Address getAddress() {
         return address;
     }
@@ -131,5 +123,13 @@ public class Person {
 
     public void setUpdatedAt(LocalDateTime updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public List<CompanyMember> getCompanyMembers() {
+        return companyMembers;
+    }
+
+    public void setCompanyMembers(List<CompanyMember> companyMembers) {
+        this.companyMembers = companyMembers;
     }
 }


### PR DESCRIPTION
- Updated `Person` entity to remove `fk_role` and add `companyMembers` collection.
- Created `CompanyMember` entity with `fk_company`, `fk_person`, and `fk_role` relationships and a unique constraint.
- Updated `Company` entity to include the `companyMembers` collection.
- Verified that `Project` and `Address` entities comply with the requirements.