### PR TITLE
feat: Implement project financial summary endpoint

### DIFF
--- a/src/main/java/com/management/financial/repository/FinancialEntryRepository.java
+++ b/src/main/java/com/management/financial/repository/FinancialEntryRepository.java
@@ -2,8 +2,15 @@ package com.management.financial.repository;
 
 import com.management.financial.model.FinancialEntry;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
 
 @Repository
 public interface FinancialEntryRepository extends JpaRepository<FinancialEntry, Integer> {
+
+    @Query("SELECT SUM(fe.amount) FROM FinancialEntry fe WHERE fe.project.id = :projectId AND fe.type = :type")
+    BigDecimal sumAmountByProjectIdAndType(@Param("projectId") Integer projectId, @Param("type") String type);
 }

--- a/src/main/java/com/management/project/controller/ProjectController.java
+++ b/src/main/java/com/management/project/controller/ProjectController.java
@@ -1,7 +1,9 @@
 package com.management.project.controller;
 
 import com.management.project.dto.ProjectCreateRequest;
+import com.management.project.dto.ProjectFinancialSummaryDTO;
 import com.management.project.dto.ProjectResponse;
+import com.management.project.service.ProjectFinancialService;
 import com.management.project.service.ProjectService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -14,14 +16,16 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/v1")
 @Tag(name = "Projects")
 public class ProjectController {
 
     private final ProjectService projectService;
+    private final ProjectFinancialService projectFinancialService;
 
-    public ProjectController(ProjectService projectService) {
+    public ProjectController(ProjectService projectService, ProjectFinancialService projectFinancialService) {
         this.projectService = projectService;
+        this.projectFinancialService = projectFinancialService;
     }
 
     @PostMapping("/projects")
@@ -50,5 +54,11 @@ public class ProjectController {
     @GetMapping("/persons/{personId}/projects")
     public ResponseEntity<List<ProjectResponse>> findByPersonId(@PathVariable Integer personId) {
         return ResponseEntity.ok(projectService.findByPersonId(personId));
+    }
+
+    @GetMapping("/projects/{projectId}/financial-summary")
+    @Operation(summary = "Gets the financial summary for a project")
+    public ResponseEntity<ProjectFinancialSummaryDTO> getFinancialSummary(@PathVariable Integer projectId) {
+        return ResponseEntity.ok(projectFinancialService.getProjectFinancialSummary(projectId));
     }
 }

--- a/src/main/java/com/management/project/dto/ProjectFinancialSummaryDTO.java
+++ b/src/main/java/com/management/project/dto/ProjectFinancialSummaryDTO.java
@@ -1,0 +1,18 @@
+package com.management.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectFinancialSummaryDTO {
+
+    private BigDecimal resourceBudget;
+    private BigDecimal actualCost;
+    private BigDecimal revenue;
+    private BigDecimal profitOrLoss;
+}

--- a/src/main/java/com/management/project/service/ProjectFinancialService.java
+++ b/src/main/java/com/management/project/service/ProjectFinancialService.java
@@ -1,0 +1,37 @@
+package com.management.project.service;
+
+import com.management.financial.repository.FinancialEntryRepository;
+import com.management.project.dto.ProjectFinancialSummaryDTO;
+import com.management.resource.repository.ProjectResourceRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+@Service
+public class ProjectFinancialService {
+
+    @Autowired
+    private ProjectResourceRepository projectResourceRepository;
+
+    @Autowired
+    private FinancialEntryRepository financialEntryRepository;
+
+    @Transactional(readOnly = true)
+    public ProjectFinancialSummaryDTO getProjectFinancialSummary(Integer projectId) {
+        BigDecimal resourceBudget = Optional.ofNullable(projectResourceRepository.sumTotalCostByProjectId(projectId))
+                .orElse(BigDecimal.ZERO);
+
+        BigDecimal expenses = Optional.ofNullable(financialEntryRepository.sumAmountByProjectIdAndType(projectId, "DESPESA"))
+                .orElse(BigDecimal.ZERO);
+
+        BigDecimal revenues = Optional.ofNullable(financialEntryRepository.sumAmountByProjectIdAndType(projectId, "RECEITA"))
+                .orElse(BigDecimal.ZERO);
+
+        BigDecimal profitOrLoss = revenues.subtract(expenses);
+
+        return new ProjectFinancialSummaryDTO(resourceBudget, expenses, revenues, profitOrLoss);
+    }
+}

--- a/src/main/java/com/management/resource/repository/ProjectResourceRepository.java
+++ b/src/main/java/com/management/resource/repository/ProjectResourceRepository.java
@@ -2,11 +2,17 @@ package com.management.resource.repository;
 
 import com.management.resource.model.ProjectResource;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Repository
 public interface ProjectResourceRepository extends JpaRepository<ProjectResource, Integer> {
     List<ProjectResource> findByProjectId(Integer projectId);
+
+    @Query("SELECT SUM(pr.unitCost * pr.quantity) FROM ProjectResource pr WHERE pr.project.id = :projectId")
+    BigDecimal sumTotalCostByProjectId(@Param("projectId") Integer projectId);
 }


### PR DESCRIPTION
- Adds a new endpoint `GET /api/v1/projects/{projectId}/financial-summary` to provide a financial overview of a project.
- Creates a `ProjectFinancialService` to handle the business logic for calculating the financial summary, including resource budget, actual costs, revenue, and profit/loss.
- Adds custom JPQL queries to `FinancialEntryRepository` and `ProjectResourceRepository` to efficiently calculate the required sums.
- Introduces `ProjectFinancialSummaryDTO` to standardize the API response.
- Updates the `ProjectController` to expose the new endpoint and injects the new service.
- Standardizes the base path for `ProjectController` to `/api/v1` for consistency.