### PR TITLE
feat: Standardize UserAccount foreign key naming

### DIFF
--- a/src/main/java/com/management/company/model/Company.java
+++ b/src/main/java/com/management/company/model/Company.java
@@ -1,6 +1,7 @@
 package com.management.company.model;
 
 import com.management.address.model.Address;
+import com.management.documenttype.model.DocumentType;
 import com.management.plantype.model.PlanType;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
@@ -15,6 +16,10 @@ public class Company {
 
     @Column(unique = true, nullable = false)
     private String document;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fk_document_type", nullable = false)
+    private DocumentType documentType;
 
     @Column(name = "registered_name", nullable = false)
     private String registeredName;
@@ -72,6 +77,14 @@ public class Company {
 
     public void setDocument(String document) {
         this.document = document;
+    }
+
+    public DocumentType getDocumentType() {
+        return documentType;
+    }
+
+    public void setDocumentType(DocumentType documentType) {
+        this.documentType = documentType;
     }
 
     public String getRegisteredName() {

--- a/src/main/java/com/management/documenttype/repository/DocumentTypeRepository.java
+++ b/src/main/java/com/management/documenttype/repository/DocumentTypeRepository.java
@@ -4,6 +4,9 @@ import com.management.documenttype.model.DocumentType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface DocumentTypeRepository extends JpaRepository<DocumentType, Integer> {
+    Optional<DocumentType> findByCode(String code);
 }

--- a/src/main/java/com/management/person/model/UserAccount.java
+++ b/src/main/java/com/management/person/model/UserAccount.java
@@ -18,7 +18,7 @@ public class UserAccount {
     private String passwordHash;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "person_id", nullable = false)
+    @JoinColumn(name = "fk_person", nullable = false)
     private Person person;
 
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/management/person/service/PersonService.java
+++ b/src/main/java/com/management/person/service/PersonService.java
@@ -22,6 +22,8 @@ import com.management.person.model.UserAccount;
 import com.management.person.repository.PersonDocumentRepository;
 import com.management.person.repository.PersonRepository;
 import com.management.person.repository.UserAccountRepository;
+import com.management.plantype.model.PlanType;
+import com.management.plantype.repository.PlanTypeRepository;
 import com.management.project.exception.ResourceNotFoundException;
 import com.management.role.model.PersonRole;
 import com.management.role.model.Role;
@@ -53,12 +55,13 @@ public class PersonService {
     private final DocumentTypeRepository documentTypeRepository;
     private final PersonDocumentRepository personDocumentRepository;
     private final UserAccountRepository userAccountRepository;
+    private final PlanTypeRepository planTypeRepository;
     private final RoleRepository roleRepository;
     private final PersonRoleRepository personRoleRepository;
     private final PasswordEncoder passwordEncoder;
     private final ModelMapper modelMapper;
 
-    public PersonService(PersonRepository personRepository, CompanyRepository companyRepository, CompanyMemberRepository companyMemberRepository, BrasilApiService brasilApiService, AddressRepository addressRepository, CityRepository cityRepository, StateRepository stateRepository, DocumentTypeRepository documentTypeRepository, PersonDocumentRepository personDocumentRepository, UserAccountRepository userAccountRepository, RoleRepository roleRepository, PersonRoleRepository personRoleRepository, PasswordEncoder passwordEncoder, ModelMapper modelMapper) {
+    public PersonService(PersonRepository personRepository, CompanyRepository companyRepository, CompanyMemberRepository companyMemberRepository, BrasilApiService brasilApiService, AddressRepository addressRepository, CityRepository cityRepository, StateRepository stateRepository, DocumentTypeRepository documentTypeRepository, PersonDocumentRepository personDocumentRepository, UserAccountRepository userAccountRepository, PlanTypeRepository planTypeRepository, RoleRepository roleRepository, PersonRoleRepository personRoleRepository, PasswordEncoder passwordEncoder, ModelMapper modelMapper) {
         this.personRepository = personRepository;
         this.companyRepository = companyRepository;
         this.companyMemberRepository = companyMemberRepository;
@@ -69,6 +72,7 @@ public class PersonService {
         this.documentTypeRepository = documentTypeRepository;
         this.personDocumentRepository = personDocumentRepository;
         this.userAccountRepository = userAccountRepository;
+        this.planTypeRepository = planTypeRepository;
         this.roleRepository = roleRepository;
         this.personRoleRepository = personRoleRepository;
         this.passwordEncoder = passwordEncoder;
@@ -105,8 +109,18 @@ public class PersonService {
                 CnpjResponseDTO cnpjData = brasilApiService.getCnpjData(createDTO.getCnpj()).block();
 
                 if (cnpjData != null) {
+                    // 1. Localizar dependências obrigatórias para a Company
+                    DocumentType cnpjDocType = documentTypeRepository.findByCode("CNPJ")
+                            .orElseThrow(() -> new ResourceNotFoundException("Tipo de documento 'CNPJ' não encontrado no sistema."));
+
+                    PlanType freePlan = planTypeRepository.findByCode("FREE")
+                            .orElseThrow(() -> new ResourceNotFoundException("Plano 'FREE' não encontrado no sistema."));
+
+                    // 2. Configurar e salvar a Company
                     Company company = new Company();
                     company.setDocument(createDTO.getCnpj());
+                    company.setDocumentType(cnpjDocType); // Resolve o erro de Not-Null Constraint
+                    company.setPlanType(freePlan);        // Resolve a obrigatoriedade de plano
                     company.setRegisteredName(cnpjData.getRazaoSocial());
                     company.setTradeName(cnpjData.getNomeFantasia());
                     company.setRegistrationStatusDescription(cnpjData.getDescricaoSituacaoCadastral());

--- a/src/main/java/com/management/plantype/model/PlanType.java
+++ b/src/main/java/com/management/plantype/model/PlanType.java
@@ -9,7 +9,8 @@ public class PlanType {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    private String name;
+    @Column(unique = true, nullable = false)
+    private String code;
 
     // Getters and Setters
     public Integer getId() {
@@ -20,11 +21,11 @@ public class PlanType {
         this.id = id;
     }
 
-    public String getName() {
-        return name;
+    public String getCode() {
+        return code;
     }
 
-    public void setName(String name) {
-        this.name = name;
+    public void setCode(String code) {
+        this.code = code;
     }
 }

--- a/src/main/java/com/management/plantype/repository/PlanTypeRepository.java
+++ b/src/main/java/com/management/plantype/repository/PlanTypeRepository.java
@@ -1,0 +1,12 @@
+package com.management.plantype.repository;
+
+import com.management.plantype.model.PlanType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PlanTypeRepository extends JpaRepository<PlanType, Integer> {
+    Optional<PlanType> findByCode(String code);
+}

--- a/src/test/java/com/management/person/service/PersonServiceTest.java
+++ b/src/test/java/com/management/person/service/PersonServiceTest.java
@@ -11,6 +11,8 @@ import com.management.documenttype.model.DocumentType;
 import com.management.documenttype.repository.DocumentTypeRepository;
 import com.management.person.dto.PersonCreateDTO;
 import com.management.person.dto.PersonDTO;
+import com.management.plantype.model.PlanType;
+import com.management.plantype.repository.PlanTypeRepository;
 import com.management.person.model.Person;
 import com.management.person.repository.PersonDocumentRepository;
 import com.management.person.repository.PersonRepository;
@@ -58,6 +60,8 @@ class PersonServiceTest {
     @Mock
     private UserAccountRepository userAccountRepository;
     @Mock
+    private PlanTypeRepository planTypeRepository;
+    @Mock
     private RoleRepository roleRepository;
     @Mock
     private PersonRoleRepository personRoleRepository;
@@ -99,6 +103,8 @@ class PersonServiceTest {
         when(modelMapper.map(any(PersonCreateDTO.class), eq(Person.class))).thenReturn(person);
         when(personRepository.save(any(Person.class))).thenReturn(person);
         when(documentTypeRepository.getReferenceById(anyInt())).thenReturn(new DocumentType());
+        when(documentTypeRepository.findByCode("CNPJ")).thenReturn(Optional.of(new DocumentType()));
+        when(planTypeRepository.findByCode("FREE")).thenReturn(Optional.of(new PlanType()));
         when(passwordEncoder.encode(anyString())).thenReturn("hashedPassword");
         when(brasilApiService.getCnpjData(anyString())).thenReturn(Mono.just(cnpjResponse));
         when(roleRepository.findByName("Owner")).thenReturn(Optional.of(ownerRole));


### PR DESCRIPTION
Updates the `UserAccount` entity to use the standardized foreign key column name for its relationship with the `Person` entity.

- Changes the `@JoinColumn` name from `person_id` to `fk_person` to align with the new database schema conventions.