### PR TITLE
fix: Resolve LazyInitializationException in CustomUserDetailsService

### DIFF
--- a/src/main/java/com/management/config/CustomUserDetailsService.java
+++ b/src/main/java/com/management/config/CustomUserDetailsService.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,6 +27,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         UserAccount userAccount = userAccountRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));


### PR DESCRIPTION
Adds the `@Transactional(readOnly = true)` annotation to the `loadUserByUsername` method in `CustomUserDetailsService`.

This ensures that the Hibernate session remains open long enough to fetch the lazily-loaded `PersonRole` entities associated with the `UserAccount`, preventing a `LazyInitializationException` from occurring within the JWT authentication filter when accessing user authorities.